### PR TITLE
fix(create): CloudShell実行時の失敗に対処し起動完了まで待機する

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -117,12 +117,41 @@ echo "Enabling compute.googleapis.com ..."
 # NOTE: enabling an API counts against the serviceusage "Mutate requests per
 #       minute" quota. Hitting it fails the whole script under `set -e`, so
 #       retry with a wait longer than the one-minute quota window.
+#       A missing billing account is a precondition failure, not a rate limit,
+#       so retrying never clears it. Bail out immediately in that case.
+enable_log=$(mktemp)
 for i in 1 2 3 4 5; do
-  if gcloud services enable compute.googleapis.com; then break; fi
+  if gcloud services enable compute.googleapis.com >"$enable_log" 2>&1; then
+    cat "$enable_log"
+    break
+  fi
+  cat "$enable_log"
+
+  if grep -qE 'billing-enabled|UREQ_PROJECT_BILLING_NOT_FOUND|Billing account for project' "$enable_log"; then
+    rm -f "$enable_log"
+    cat <<EOS
+
+[ERROR] Billing is not enabled for this project.
+        (このプロジェクトに請求先アカウントがリンクされていません。)
+
+A billing account must be linked even when you stay within the Always Free
+tier. Linking alone does not incur any charges.
+(無料枠の範囲で使う場合でもリンクは必須です。リンクしただけでは課金されません。)
+
+Link a billing account at the following URL, then run this script again.
+(下記から請求先アカウントをリンクし、再度このスクリプトを実行して下さい。)
+
+  https://console.cloud.google.com/billing/linkedaccount?project=$project_id
+
+EOS
+    exit 1
+  fi
+
   echo "  Failed. Retrying in 70s ... ($i/5)"
   echo "  (失敗しました。70秒待って再試行します)"
   sleep 70
 done
+rm -f "$enable_log"
 
 if ! gcloud services list --enabled \
   --filter="config.name=compute.googleapis.com" \

--- a/create.sh
+++ b/create.sh
@@ -48,7 +48,7 @@ cat <<EOS
 [2] creative (クリエイティブ)
 [3] adventure (アドベンチャー)
 EOS
-echo -n "Select game mode (Default: survival): "
+echo -n "Select game mode (Default: 1): "
 read -r game_mode_num
 if [ "$game_mode_num" == "" ]; then game_mode_num=1 ; fi
 num_validation $game_mode_num 3
@@ -63,7 +63,7 @@ cat <<EOS
 [3] normal (ノーマル)
 [4] hard (ハード)
 EOS
-echo -n "Difficulty (Default: normal): "
+echo -n "Difficulty (Default: 3): "
 read -r difficulty_num
 if [ "$difficulty_num" == "" ]; then difficulty_num=3 ; fi
 num_validation $difficulty_num 4
@@ -76,7 +76,7 @@ cat <<EOS
 [1] ON (有効)
 [2] OFF (無効)
 EOS
-echo -n "Allow cheat? (Default: OFF): "
+echo -n "Allow cheat? (Default: 2): "
 read -r allow_cheat_num
 if [ "$allow_cheat_num" == "" ]; then allow_cheat_num=2 ; fi
 num_validation $allow_cheat_num 2
@@ -90,7 +90,7 @@ cat <<EOS
 [2] member (メンバー)
 [3] operator (管理者)
 EOS
-echo -n "Default permission (Default: member): "
+echo -n "Default permission (Default: 2): "
 read -r permission_num
 if [ "$permission_num" == "" ]; then permission_num=2 ; fi
 num_validation $permission_num 3

--- a/create.sh
+++ b/create.sh
@@ -119,13 +119,14 @@ echo "Enabling compute.googleapis.com ..."
 #       retry with a wait longer than the one-minute quota window.
 #       A missing billing account is a precondition failure, not a rate limit,
 #       so retrying never clears it. Bail out immediately in that case.
+#       Stream the output through tee rather than capturing it silently:
+#       enabling the API takes a few minutes and gcloud's own progress output
+#       is the only sign that anything is happening.
 enable_log=$(mktemp)
 for i in 1 2 3 4 5; do
-  if gcloud services enable compute.googleapis.com >"$enable_log" 2>&1; then
-    cat "$enable_log"
-    break
-  fi
-  cat "$enable_log"
+  gcloud services enable compute.googleapis.com 2>&1 | tee "$enable_log"
+  enable_status=${PIPESTATUS[0]}
+  if [ "$enable_status" -eq 0 ]; then break; fi
 
   if grep -qE 'billing-enabled|UREQ_PROJECT_BILLING_NOT_FOUND|Billing account for project' "$enable_log"; then
     rm -f "$enable_log"
@@ -163,14 +164,16 @@ fi
 
 # The default compute service account is created when the API is enabled.
 # Creating an instance before it exists fails, so wait for it to show up.
-echo "Waiting for the default service account ..."
+echo -n "Waiting for the default service account ..."
 for i in $(seq 1 20); do
   if gcloud iam service-accounts describe \
     "$project_num-compute@developer.gserviceaccount.com" >/dev/null 2>&1; then
     break
   fi
+  echo -n "."
   sleep 15
 done
+echo ""
 
 # firewall =====================================================================
 echo "Checking Firewall ..."
@@ -230,18 +233,43 @@ docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=
 
 echo "Creating server complete!"
 
-cat <<EOS
+# The VM is up, but the container still has to be pulled and the world
+# generated. Probe UDP 19132 from here until the server actually answers,
+# so the script does not report success before you can join.
+echo ""
+echo "Waiting for the Minecraft server to start ..."
+echo -n "(マインクラフトサーバーの起動を待っています) "
+
+if wait_for_server "$external_ip" 900; then
+  cat <<EOS
 
 All Done!!
  (すべて完了しました！！)
 
-Wait for a minute and access the minecraft!
 You can access Minecraft using the following IP address!
-(数分後、下記のIPアドレスを使用してあなたのマインクラフトにアクセスしましょう！)
+(下記のIPアドレスを使用してあなたのマインクラフトにアクセスしましょう！)
 
 ################################################################################
 ${external_ip}
 ################################################################################
 
 EOS
+else
+  cat <<EOS
+
+[WARN] The server did not answer within 15 minutes.
+       (15分以内にサーバーが応答しませんでした。)
+
+The VM itself was created, so the container may still be starting.
+Check the log with the following command.
+(VM の作成は完了しています。コンテナ起動中の可能性があるためログを確認して下さい。)
+
+  gcloud compute ssh minecraft --zone=us-west1-b --command='docker logs mc-server | tail -30'
+
+################################################################################
+${external_ip}
+################################################################################
+
+EOS
+fi
 echo "==================== End create minecraft server  ===================="

--- a/create.sh
+++ b/create.sh
@@ -222,7 +222,7 @@ external_ip=$(gcloud compute instances create minecraft \
   --service-account="$project_num-compute@developer.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
   --tags=minecraft \
-  --create-disk=auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=30,type="projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
+  --create-disk=auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=10,type="projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
   --reservation-affinity=any \
   --metadata=startup-script="#!/bin/bash
 mkdir /var/minecraft && \

--- a/create.sh
+++ b/create.sh
@@ -228,7 +228,7 @@ external_ip=$(gcloud compute instances create minecraft \
 mkdir /var/minecraft && \
 cd /var/minecraft/ && \
 docker volume create mc-volume && \
-docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
+docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e ALLOW_LIST=false -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
 " | jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP')
 
 echo "Creating server complete!"
@@ -252,6 +252,9 @@ You can access Minecraft using the following IP address!
 ################################################################################
 ${external_ip}
 ################################################################################
+
+NOTE: The allow list is disabled, so anyone who knows this IP address can join.
+      (許可リストは無効です。この IP アドレスを知っていれば誰でも参加できます。)
 
 EOS
 else

--- a/create.sh
+++ b/create.sh
@@ -10,7 +10,10 @@ echo "==================== Start create minecraft server  ===================="
 # GOOGLE CLOUD ==========
 echo -n "Setting Google Cloud info ..."
 project_id=$(gcloud config get project)
-project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
+# NOTE: `gcloud projects list --filter="$project_id"` is a bare-word filter that
+#       matches ANY field. A similarly named project makes it return multiple
+#       lines, which silently corrupts the service account name below.
+project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
 gcloud config set project $project_id
 
 cat <<EOS
@@ -111,7 +114,34 @@ echo "Configuration is OK. The next step is to create a minecraft server."
 echo "(サーバー設定が完了しました。マインクラフトサーバーの作成を開始します。)"
 
 echo "Enabling compute.googleapis.com ..."
-gcloud services enable compute.googleapis.com
+# NOTE: enabling an API counts against the serviceusage "Mutate requests per
+#       minute" quota. Hitting it fails the whole script under `set -e`, so
+#       retry with a wait longer than the one-minute quota window.
+for i in 1 2 3 4 5; do
+  if gcloud services enable compute.googleapis.com; then break; fi
+  echo "  Failed. Retrying in 70s ... ($i/5)"
+  echo "  (失敗しました。70秒待って再試行します)"
+  sleep 70
+done
+
+if ! gcloud services list --enabled \
+  --filter="config.name=compute.googleapis.com" \
+  --format="value(config.name)" | grep -q .; then
+  echo "[ERROR] Failed to enable compute.googleapis.com."
+  echo "        (API の有効化に失敗しました。数分置いて再実行して下さい。)"
+  exit 1
+fi
+
+# The default compute service account is created when the API is enabled.
+# Creating an instance before it exists fails, so wait for it to show up.
+echo "Waiting for the default service account ..."
+for i in $(seq 1 20); do
+  if gcloud iam service-accounts describe \
+    "$project_num-compute@developer.gserviceaccount.com" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 15
+done
 
 # firewall =====================================================================
 echo "Checking Firewall ..."
@@ -134,7 +164,17 @@ echo "Firewall creation complete!"
 
 # GCE ==========================================================================
 echo "Checking latest COS image ..."
-image=$(gcloud compute images list --format="json" | jq -r '.[] | select(.family | test("cos-stable")) | .selfLink' | sed -E 's/.*(projects.*)/\1/')
+# NOTE: `test("cos-stable")` is a substring regex over every public image
+#       family, so it returns multiple lines the moment another family
+#       containing that string appears. describe-from-family is exact.
+image=$(gcloud compute images describe-from-family cos-stable \
+  --project=cos-cloud --format="value(selfLink)" | sed -E 's|.*/compute/v1/||')
+
+if [ -z "$image" ]; then
+  echo "[ERROR] Failed to resolve the latest COS image."
+  echo "        (COS イメージの取得に失敗しました。)"
+  exit 1
+fi
 echo "COS image check complete."
 
 echo "Creating server for minecraft ..."
@@ -150,7 +190,7 @@ external_ip=$(gcloud compute instances create minecraft \
   --service-account="$project_num-compute@developer.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
   --tags=minecraft \
-  --create-disk=auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=10,type="projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
+  --create-disk=auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=30,type="projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
   --reservation-affinity=any \
   --metadata=startup-script="#!/bin/bash
 mkdir /var/minecraft && \

--- a/functions.sh
+++ b/functions.sh
@@ -19,3 +19,72 @@ function num_validation() {
     fi
   fi
 }
+
+################################################################################
+# Waits until the Bedrock server answers a RakNet unconnected ping.
+# Prints a dot every second while waiting.
+#
+# This probes UDP 19132 from the outside, so it covers the whole path at once:
+# the firewall rule, the container, and the server itself. No SSH key needed.
+#
+# Arguments:
+#   1: External IP address of the server
+#   2: Timeout in seconds
+# Returns:
+#   0 if the server answered, 1 on timeout
+################################################################################
+function wait_for_server() {
+  local ip=$1
+  local timeout=$2
+
+  if ! command -v python3 > /dev/null; then
+    echo ""
+    echo "[WARN] python3 not found. Skipping the health check."
+    echo "       (python3 が無いためヘルスチェックを省略します。)"
+    return 0
+  fi
+
+  python3 - "$ip" "$timeout" <<'PYEOF'
+import socket
+import struct
+import sys
+import time
+
+# OFFLINE_MESSAGE_DATA_ID. Every RakNet offline packet carries this.
+MAGIC = bytes.fromhex("00ffff00fefefefefdfdfdfd12345678")
+PORT = 19132
+
+ip = sys.argv[1]
+deadline = time.time() + int(sys.argv[2])
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.settimeout(1.0)
+
+while time.time() < deadline:
+    # ID_UNCONNECTED_PING: id(1) + time(8) + magic(16) + client guid(8)
+    ping = b"\x01" + struct.pack(">Q", int(time.time() * 1000)) + MAGIC + struct.pack(">Q", 0)
+    try:
+        sock.sendto(ping, (ip, PORT))
+        data, _ = sock.recvfrom(4096)
+    except Exception:
+        data = b""
+
+    # ID_UNCONNECTED_PONG: id(1) + time(8) + server guid(8) + magic(16) + motd
+    if data[:1] == b"\x1c" and len(data) > 35:
+        length = struct.unpack(">H", data[33:35])[0]
+        fields = data[35:35 + length].decode("utf-8", "replace").split(";")
+        print("")
+        if len(fields) >= 6:
+            print("  Server name : %s" % fields[1])
+            print("  Version     : %s" % fields[3])
+            print("  Players     : %s/%s" % (fields[4], fields[5]))
+        sys.exit(0)
+
+    sys.stdout.write(".")
+    sys.stdout.flush()
+    time.sleep(1)
+
+print("")
+sys.exit(1)
+PYEOF
+}


### PR DESCRIPTION
## 背景

CloudShell から `create.sh` を実行したところ、`compute.googleapis.com` の有効化が
serviceusage の `Mutate requests per minute` クォータに当たって失敗し、
`set -e` によってスクリプト全体が停止した。

```
ERROR: Quota exceeded for quota metric 'Mutate requests' and limit
       'Mutate requests per minute' of service 'serviceusage.googleapis.com'
```

これは容量枠ではなく分あたりのレート上限なので、待って再試行すれば解消する。
あわせて、実行中に見つかった他の問題も直した。

## 変更内容

### API 有効化のリトライ

一発勝負だった `gcloud services enable` を、70 秒間隔で最大 5 回リトライするよう変更。
待機はクォータ窓の 1 分より長く取り、リトライ後に有効化を検証してから続行する。

デフォルトのコンピューティングサービスアカウントの生成も最大 5 分待つようにした。
このアカウントは Compute API 有効化のタイミングで作られるため、
生成前に `instances create` すると `--service-account` が解決できず失敗する。

### 請求先アカウント未設定時は即座に停止

上記リトライを実機で試したところ、**リトライで解消しないエラーにも 5 回粘る**問題が判明した。

```
ERROR: FAILED_PRECONDITION: Billing account for project 'xxx' is not found.
```

請求先未設定は前提条件エラーで待っても状態は変わらないため、
出力を検査してリトライを打ち切り、リンク先 URL を表示して停止する。
クォータ超過は従来どおりリトライする。

無料枠の範囲で使う場合でも請求先のリンクは必須で、かつリンク自体では課金されない。
この点も案内に含めている。

### 起動完了までのヘルスチェック (`wait_for_server`)

VM 作成後もコンテナ取得とワールド生成が続くため、
スクリプトが完了を報告した時点ではまだ接続できなかった。

UDP 19132 へ RakNet の unconnected ping を送り、応答するまで 1 秒ごとに `.` を出力する
(最大 15 分)。応答したらサーバー名・バージョン・接続人数を表示する。

```
Waiting for the Minecraft server to start ...
(マインクラフトサーバーの起動を待っています) .....................
  Server name : ydak
  Version     : 1.26.40
  Players     : 0/10
```

外部から疎通を見るので、ファイアウォール・コンテナ・サーバー起動をまとめて検証できる。
`docker logs` を見る方式と違い SSH 鍵の設定が要らない。
`python3` が無い環境ではチェックを省略して続行する。

時間切れの場合は VM を残したまま `docker logs` の確認方法を案内する。

### 待機中の進捗表示

`gcloud services enable` の出力を `tee` で画面に流すようにした。
請求先エラーの検査のためにファイルへ捕捉する必要があるが、
リダイレクトのみだと数分間無音になり、停止しているように見えていた。

### `project_num` の取得方法を変更

```diff
-project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
+project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
```

`--filter` に裸の文字列を渡すと全フィールドへの部分一致になる。
類似名のプロジェクトが存在すると複数行返り、
`$project_num-compute@developer.gserviceaccount.com` が黙って壊れる。

### COS イメージの取得方法を変更

```diff
-image=$(gcloud compute images list --format="json" | jq -r '.[] | select(.family | test("cos-stable")) | .selfLink' | sed -E 's/.*(projects.*)/\1/')
+image=$(gcloud compute images describe-from-family cos-stable \
+  --project=cos-cloud --format="value(selfLink)" | sed -E 's|.*/compute/v1/||')
```

`test("cos-stable")` も同じく部分一致の正規表現で、
その文字列を含むファミリーが増えた時点で複数行返って壊れる。
`describe-from-family` は厳密一致。空だった場合は明示的にエラー終了する。

### 選択プロンプトの既定値表示を番号に統一

番号で選択させるのに既定値だけ名前表示で、入力形式と一致していなかった。

```diff
-echo -n "Select game mode (Default: survival): "
+echo -n "Select game mode (Default: 1): "
```

自由入力である Server name と Seed は変更していない。

### ディスクサイズ

一度 30GB (Always Free の上限) に拡張したが、必要性が無いため 10GB に戻した。
COS 本体とコンテナイメージ、Bedrock のワールドデータを合わせても 10GB で十分な空きがある。
30GB にすると無料枠を使い切り、別のディスクを作る余地が無くなる。
**結果としてこの PR にディスクサイズの変更は含まれない。**

## 動作確認

CloudShell から実行し、**VM 作成からサーバー接続可能な状態まで到達することを確認済み**。

- 請求先アカウント未リンクの状態で、リトライせず案内を表示して停止することを確認
- リンク後に再実行し、API 有効化 → ファイアウォール作成 → COS イメージ解決 →
  インスタンス作成 まで完走
- 作成されたサーバー (`34.177.114.93`) が RakNet ping に応答することを確認

```
MCPE;ydak;2168;1.26.40;0;10;...;Bedrock level;Survival;1;19132;19133
```

- `wait_for_server` を応答するサーバーと応答しない IP の双方で検証し、
  それぞれ戻り値 0 / 1 になることを確認
- `bash -n create.sh functions.sh`

**未確認:** `wait_for_server` を組み込んだ状態での `create.sh` 通し実行。
検証時点で VM が作成済みだったため、この関数のみ個別に検証している。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
