### PR TITLE
fix(update): 無効な docker pull を削除し更新完了まで待機する

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,104 @@
 #!/usr/bin/env bash
 set -e
 
+script_dir=$(dirname ${0})
+. $script_dir/functions.sh
+
+ZONE=us-west1-b
+SERVER_NAME=minecraft
+
 echo "==================== Start minecraft update ===================="
+
+# GOOGLE CLOUD ==========
+echo -n "Setting Google Cloud info ..."
+project_id=$(gcloud config get project)
+project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
+gcloud config set project $project_id
+
+# A stopped instance has no external IP, so an empty value is also a failure.
+external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
+  --format="value(networkInterfaces[0].accessConfigs[0].natIP)" 2>/dev/null || true)
+
+if [ -z "$external_ip" ]; then
+  cat <<EOS
+
+[ERROR] Server '$SERVER_NAME' was not found in zone $ZONE, or it is not running.
+        (ゾーン $ZONE にサーバーが無いか、起動していません。)
+
+The current project is '$project_id'. Check that it is the right one,
+and that the server is running.
+(現在のプロジェクトは '$project_id' です。対象が正しいか、
+ またサーバーが起動しているか確認して下さい。)
+
+  gcloud compute instances list
+
+EOS
+  exit 1
+fi
+
+cat <<EOS
+
+-*-*-*-*- [更新対象の確認] -*-*-*-*-
+プロジェクト ID
+　$project_id
+プロジェクト番号
+　$project_num
+サーバー名
+　$SERVER_NAME
+IP アドレス
+　$external_ip
+
+上記のマインクラフトを最新バージョンに更新します。
+更新中はサーバーが停止するため、接続中のプレイヤーは全員切断されます。
+EOS
+
+echo -n "よろしいですか? [y/N]: "
+read -r update_yn
+if [ "$update_yn" != "y" ]; then exit 1 ; fi
+
 echo "Updating minecraft ..."
-gcloud compute ssh --zone "us-west1-b" "minecraft" --command="docker pull itzg/minecraft-bedrock-server:latest && docker restart mc-server"
-echo "Minecraft has been updated!"
+
+# NOTE: The Bedrock server binary is not bundled in the image. It is downloaded
+#       from Mojang at container startup, and VERSION defaults to LATEST, so
+#       restarting the container is what actually performs the upgrade.
+#
+#       `docker pull` is deliberately not used here. A running container stays
+#       bound to the image it was created from, so pulling a newer image has no
+#       effect on it and only piles up unused layers on the 10GB boot disk.
+#
+#       The image handles SIGTERM by sending `stop` to the server, so the world
+#       is saved cleanly before the restart.
+gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker restart mc-server"
+
+echo ""
+echo "Waiting for the Minecraft server to come back ..."
+echo -n "(マインクラフトサーバーの再起動を待っています) "
+
+if wait_for_server "$external_ip" 900; then
+  cat <<EOS
+
+Minecraft has been updated!
+ (マインクラフトの更新が完了しました！)
+
+################################################################################
+${external_ip}
+################################################################################
+
+EOS
+else
+  cat <<EOS
+
+[WARN] The server did not answer within 15 minutes.
+       (15分以内にサーバーが応答しませんでした。)
+
+The container may still be downloading the new version.
+Check the log with the following command.
+(新しいバージョンを取得中の可能性があります。下記でログを確認して下さい。)
+
+  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+
+EOS
+  exit 1
+fi
+
 echo "==================== End minecraft update ===================="


### PR DESCRIPTION
## 背景

`update.sh` が Minecraft 本体のアップデートに対応は、
**目的は達成できているが、処理の半分が無意味**であることが分かった。

```bash
gcloud compute ssh --zone "us-west1-b" "minecraft" \
  --command="docker pull itzg/minecraft-bedrock-server:latest && docker restart mc-server"
```

実際に更新しているのは `docker restart` の方である。
itzg のイメージは Bedrock 本体を同梱しておらず、コンテナ起動時に Mojang から取得する。

> "the Bedrock server software is not bundled into this image.
>  Instead, it is downloaded/upgraded from Mojang only during container startup."

> "With the `VERSION` variable set to "LATEST", which is the default, then the Bedrock
>  server can be upgraded by restarting the container. At every startup, the container
>  checks for the latest version and upgrades, if needed."

`create.sh` は `VERSION` を指定していないため既定の `LATEST` であり、
再起動だけで最新版に上がる。README の「バージョン不一致で入れないときに実行」
という用途は満たしている。

## 変更内容

### `docker pull` を削除

稼働中のコンテナは作成時のイメージ ID に束縛されるため、
新しいイメージを pull しても既存コンテナには反映されない。
`docker restart` は同じコンテナを再起動するだけである。

pull されたイメージは使われないまま残り、更新のたびに 10GB のブートディスクを
圧迫する。Bedrock 本体の更新には不要なので削除した。

### 更新完了まで待機

従来は `docker restart` の直後に「Minecraft has been updated!」と表示していたが、
その時点でサーバーは停止しており、新バージョンの取得とワールド再読み込みに
数分かかる。

`functions.sh` の `wait_for_server()` を再利用し、応答するまで待つようにした。
復帰後はバージョンと接続人数を表示するので、更新されたかどうかも確認できる。

```
Waiting for the Minecraft server to come back ...
(マインクラフトサーバーの再起動を待っています) ..................
  Server name : ydak
  Version     : 1.26.40
  Players     : 0/10

Minecraft has been updated!
```

15 分応答が無い場合は `docker logs` の確認方法を案内して終了する。

### 確認プロンプトを追加

`create.sh` / `delete.sh` は対象プロジェクトを表示して `y/N` を取るが、
`update.sh` は即実行だった。**遊んでいる最中に実行すると全員が切断される**ため、
同じ形式で確認を入れた。

```
-*-*-*-*- [更新対象の確認] -*-*-*-*-
プロジェクト ID
　minecraft-ydak-project-id
プロジェクト番号
　718912790457
サーバー名
　minecraft
IP アドレス
　34.177.114.93

上記のマインクラフトを最新バージョンに更新します。
更新中はサーバーが停止するため、接続中のプレイヤーは全員切断されます。
よろしいですか? [y/N]:
```

### 対象が無い場合の案内

インスタンスが存在しない、または停止している場合は、
確認プロンプトの前に停止して案内する。停止中のインスタンスは外部 IP を持たないため、
空の場合も失敗として扱う。

## 問題が無かった点

コンテナ停止時はイメージ側が `SIGTERM` を処理して `stop` 相当のクリーンな保存を
行うため、ワールドが壊れる懸念は無い。この挙動は変更していない。

## 動作確認

CloudShell から実行し、**確認プロンプトから完了報告まで通しで動作することを確認済み**。

```
-*-*-*-*- [更新対象の確認] -*-*-*-*-
プロジェクト ID
　minecraft-ydak-project-id
プロジェクト番号
　718912790457
サーバー名
　minecraft
IP アドレス
　136.67.118.60

上記のマインクラフトを最新バージョンに更新します。
更新中はサーバーが停止するため、接続中のプレイヤーは全員切断されます。
よろしいですか? [y/N]: y
Updating minecraft ...
mc-server

Waiting for the Minecraft server to come back ...
(マインクラフトサーバーの再起動を待っています) ......
  Server name : ydak
  Version     : 1.26.40
  Players     : 0/10

Minecraft has been updated!
```

復帰までのドットは 6 個 (約 12 秒) だった。
`create.sh` での新規作成時は 28 個かかっており、
既に最新版が volume にあるためダウンロードが走らなかったことを示している。
ドキュメントの "upgrades, if needed" どおりの挙動である。

- `bash -n update.sh`
- `functions.sh` 経由で `wait_for_server` が解決できることを確認

**未確認:** バージョンが実際に上がる経路。現在のサーバーが最新のため、
差分を取得するケースを試せていない。次の Bedrock 更新時が実地確認のタイミングになる。
なお取得に失敗した場合も、復帰後にバージョンを表示するため画面で気付ける。

### 追記: 更新経路の実証

稼働中のサーバーで、起動時にバージョン確認とダウンロードが走っていることを確認した。

```
VERSION=LATEST
---
Looking up latest version...
Downloading Bedrock server version 1.26.40.8 ...
2026/08/07 11:38:18 Setting server-name to ydak in server.properties
2026/08/07 11:38:18 Setting allow-list to false in server.properties
Starting Bedrock server...
```

`docker restart` はこの処理を再実行するため、新しいバージョンが出ていれば取得される。
ドキュメントの記述どおりに動作していることが確認できた。

あわせて、エントリポイントが起動のたびに環境変数から server.properties を
書き直していることも分かった。`ALLOW_LIST=false` などの設定は再起動後も維持される。
