### PR TITLE
feat(ci): shellcheck 実装

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,43 @@
+name: shellcheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Catches parse errors only: unclosed quotes, missing fi/done,
+      # broken heredoc terminators. Cheap, and it runs before shellcheck
+      # so a syntax error is reported as such rather than as a pile of
+      # confusing lint findings.
+      - name: Syntax check (bash -n)
+        run: |
+          for f in *.sh; do
+            echo "== $f"
+            bash -n "$f"
+          done
+
+      # The GitHub-hosted Ubuntu image ships shellcheck, but install it if
+      # that ever stops being true.
+      - name: Ensure shellcheck is available
+        run: |
+          if ! command -v shellcheck > /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+          fi
+          shellcheck --version
+
+      # -x follows sourced files, so the arrays defined in const.sh and the
+      # functions in functions.sh resolve instead of being reported as
+      # undefined in the scripts that source them.
+      - name: ShellCheck
+        run: shellcheck -x --shell=bash *.sh

--- a/const.sh
+++ b/const.sh
@@ -1,3 +1,7 @@
+# These arrays are consumed by the scripts that source this file. ShellCheck
+# analyses each file on its own, so it cannot see those uses from here.
+# shellcheck disable=SC2034
+
 game_mode_list=(survival creative adventure)
 difficulty_list=(peaceful easy normal hard)
 allow_cheat_list=(true false)

--- a/create.sh
+++ b/create.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-script_dir=$(dirname ${0})
-. $script_dir/functions.sh
-. $script_dir/const.sh
+script_dir=$(dirname "${0}")
+# shellcheck source=functions.sh
+. "$script_dir/functions.sh"
+# shellcheck source=const.sh
+. "$script_dir/const.sh"
 
 echo "==================== Start create minecraft server  ===================="
 
@@ -14,7 +16,7 @@ project_id=$(gcloud config get project)
 #       matches ANY field. A similarly named project makes it return multiple
 #       lines, which silently corrupts the service account name below.
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project $project_id
+gcloud config set project "$project_id"
 
 cat <<EOS
 
@@ -51,7 +53,7 @@ EOS
 echo -n "Select game mode (Default: 1): "
 read -r game_mode_num
 if [ "$game_mode_num" == "" ]; then game_mode_num=1 ; fi
-num_validation $game_mode_num 3
+num_validation "$game_mode_num" 3
 game_mode=${game_mode_list[$game_mode_num-1]}
 
 # DIFFICULTY ==========
@@ -66,7 +68,7 @@ EOS
 echo -n "Difficulty (Default: 3): "
 read -r difficulty_num
 if [ "$difficulty_num" == "" ]; then difficulty_num=3 ; fi
-num_validation $difficulty_num 4
+num_validation "$difficulty_num" 4
 difficulty=${difficulty_list[$difficulty_num-1]}
 
 # CHEAT ==========
@@ -79,7 +81,7 @@ EOS
 echo -n "Allow cheat? (Default: 2): "
 read -r allow_cheat_num
 if [ "$allow_cheat_num" == "" ]; then allow_cheat_num=2 ; fi
-num_validation $allow_cheat_num 2
+num_validation "$allow_cheat_num" 2
 allow_cheat=${allow_cheat_list[$allow_cheat_num-1]}
 
 # PERMISSION ==========
@@ -93,7 +95,7 @@ EOS
 echo -n "Default permission (Default: 2): "
 read -r permission_num
 if [ "$permission_num" == "" ]; then permission_num=2 ; fi
-num_validation $permission_num 3
+num_validation "$permission_num" 3
 permission=${permission_num_list[$permission_num-1]}
 
 # SEED ==========
@@ -222,7 +224,7 @@ external_ip=$(gcloud compute instances create minecraft \
   --service-account="$project_num-compute@developer.gserviceaccount.com" \
   --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
   --tags=minecraft \
-  --create-disk=auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=10,type="projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
+  --create-disk="auto-delete=yes,boot=yes,device-name=minecraft,image=$image,mode=rw,size=10,type=projects/$project_id/zones/us-west1-b/diskTypes/pd-standard" --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
   --reservation-affinity=any \
   --metadata=startup-script="#!/bin/bash
 mkdir /var/minecraft && \

--- a/delete.sh
+++ b/delete.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-script_dir=$(dirname ${0})
-. $script_dir/functions.sh
-. $script_dir/const.sh
+script_dir=$(dirname "${0}")
+# shellcheck source=functions.sh
+. "$script_dir/functions.sh"
+# shellcheck source=const.sh
+. "$script_dir/const.sh"
 
 echo "==================== Start delete minecraft server  ===================="
 
@@ -11,7 +13,7 @@ echo "==================== Start delete minecraft server  ===================="
 echo -n "Setting Google Cloud info ..."
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
-gcloud config set project $project_id
+gcloud config set project "$project_id"
 
 SERVER_NAME=minecraft
 FIREWALL_RULE_NAME=minecraft

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-script_dir=$(dirname ${0})
-. $script_dir/functions.sh
+script_dir=$(dirname "${0}")
+# shellcheck source=functions.sh
+. "$script_dir/functions.sh"
 
 ZONE=us-west1-b
 SERVER_NAME=minecraft
@@ -13,7 +14,7 @@ echo "==================== Start minecraft update ===================="
 echo -n "Setting Google Cloud info ..."
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project $project_id
+gcloud config set project "$project_id"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \


### PR DESCRIPTION
## 背景

シェルスクリプトの静的解析が無く、構文は正しいが動かない類のミスをレビューでしか
拾えていなかった。今回の一連の修正で踏んだ問題の多くはこの型だった。

- `set -e` 下で `[ -n "$X" ] && arr+=(...)` が意図せずスクリプトを終了させる
- パイプの終了ステータスの取り違え (`PIPESTATUS` で対処)
- 複数行を返しうるコマンド置換

`bash -n` はパースしか見ないため、これらは全て通過してしまう。

## 変更内容

### `.github/workflows/shellcheck.yml` を追加

`main` への push と pull request で以下を実行する。

| ステップ | 内容 |
|---|---|
| `bash -n` | パースのみ。クォートの閉じ忘れ、`fi` / `done` の対応漏れ、ヒアドキュメントの終端ミス |
| `shellcheck -x` | 静的解析。未クォート変数、`set -e` との相性、パイプの罠など |

`-x` は source 先を追跡する。これが無いと `const.sh` の配列や `functions.sh` の
関数が「未定義」として報告される。

`shellcheck` は GitHub のランナーイメージに同梱されているが、
将来同梱されなくなった場合に備えて `apt` で導入する分岐を入れてある。

### 既存の指摘を解消

導入時点で `shellcheck -x` は 20 件を報告していた。**error は 0 件**で、
現状の値にスペースが含まれないため実害は出ていなかったが、
CI を緑にするため解消した。

| コード | 件数 | 内容 |
|---|---|---|
| SC2086 | 16 | 変数展開のクォート漏れ (`$script_dir` / `$project_id` / `num_validation` の引数 / `--create-disk` の値) |
| SC2034 | 4 | `const.sh` の配列が未使用と判定される |

SC2034 は誤検知である。配列は source 先の `create.sh` で使われているが、
shellcheck はファイル単位で解析するためここからは見えない。
理由をコメントで添えたうえで無効化した。

あわせて、source 行に `# shellcheck source=` ディレクティブを付けて
追跡を確実にした。

## 挙動への影響

`num_validation` の引数をクォートしたことで、値が空の場合も引数が 2 つ渡るように
なる。呼び出し前に既定値を入れているため、実挙動は変わらない。

`--create-disk` は値全体をクォートする形に変えたが、渡される文字列は同一である。

## 動作確認

- `shellcheck -x --shell=bash *.sh` → 指摘 0 件 (exit 0)
- `bash -n` → 5 ファイルすべて OK
- ワークフローの YAML がパースできることを確認

このプルリクエスト自体で `pull_request` トリガーが動くので、
CI の実動作はここで確認できる。
