### PR TITLE
fix(mc): curl から実行すると入力待ちで停止する問題を修正

### DIFF
--- a/mc.sh
+++ b/mc.sh
@@ -62,12 +62,17 @@ for cmd in curl tar; do
 done
 
 # When this script is piped into a shell, stdin is the pipe rather than the
-# terminal. Both the menu below and the prompts in create.sh would then read
-# whatever is left of this script, or hit EOF immediately. Reconnect stdin to
-# the terminal before anything asks a question. Skipped when there is no
-# terminal, which is handled where the menu is shown.
-if [ -c /dev/tty ] && (exec < /dev/tty) 2> /dev/null; then
-  exec < /dev/tty
+# terminal, so the menu below and the prompts in create.sh would read whatever
+# is left of this script instead of the user's answer.
+#
+# The fix is NOT `exec < /dev/tty`. The shell is reading this very script from
+# stdin, so replacing stdin makes it read the remaining lines from the terminal
+# and hang forever, before even reaching the first echo. Redirect per command
+# instead: that is undone as soon as the command returns, leaving the shell's
+# own read of this script alone.
+tty_available=0
+if [ -c /dev/tty ] && (: < /dev/tty) 2> /dev/null; then
+  tty_available=1
 fi
 
 echo "==================== gcp-minecraft ===================="
@@ -92,7 +97,7 @@ fi
 
 # ACTION ==========
 if [ "$ACTION" == "" ]; then
-  if [ ! -t 0 ]; then
+  if [ "$tty_available" == "0" ]; then
     echo "[ERROR] No terminal is available, so the menu cannot be shown."
     echo "        (端末が無いためメニューを表示できません。)"
     echo "        Pass the action directly: ... | bash -s -- create"
@@ -108,7 +113,7 @@ if [ "$ACTION" == "" ]; then
 [3] delete (マインクラフトサーバーを削除)
 EOS
   echo -n "Select action (Default: 1): "
-  read -r action_num
+  read -r action_num < /dev/tty
   if [ "$action_num" == "" ]; then action_num=1 ; fi
   num_validation "$action_num" 3
   ACTION=${action_list[$action_num-1]}
@@ -120,4 +125,12 @@ if [ ! -f "${work_dir}/${ACTION}.sh" ]; then
   exit 1
 fi
 
-bash "${work_dir}/${ACTION}.sh"
+# Same reasoning as above: give the child the terminal through a redirect on
+# this one command. Without a terminal, feed it /dev/null so that its prompts
+# hit EOF and fall back to their defaults, rather than eating whatever is left
+# of this script on stdin.
+if [ "$tty_available" == "1" ]; then
+  bash "${work_dir}/${ACTION}.sh" < /dev/tty
+else
+  bash "${work_dir}/${ACTION}.sh" < /dev/null
+fi


### PR DESCRIPTION
## 不具合

README の手順どおりに実行すると、**出力が一切無いまま停止する**。

```bash
curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash
```

バナーすら出ない。v1.8.0 で入った `mc.sh` の不具合。

## 原因

標準入力の差し替え方が誤っていた。

パイプで渡した場合、**シェルは `mc.sh` 自身を fd 0 から読んでいる。**
そこへ `exec` で fd 0 を差し替えると、シェルは残りのスクリプトを端末から
読もうとして入力待ちになる。最初の `echo` にすら到達しない。

```bash
# 誤り
if [ -c /dev/tty ] && (exec < /dev/tty) 2> /dev/null; then
  exec < /dev/tty
fi
```

最小再現。`B` が出力されない。

```console
$ printf 'echo A\nexec < /dev/null\necho B\n' | bash
A
```

`/dev/tty` を通常ファイルに置き換えて再現したところ、
差し替え先の内容がスクリプトの続きとして実行されることを確認した。

```
bash: line 72: 3: command not found
```

`3` はメニューへの入力のつもりで用意した内容である。
実際の端末では、ユーザーがスクリプトの続きを入力するのを待ち続けることになる。

## 修正

`exec` をやめ、コマンド単位のリダイレクトにする。
こちらはコマンドの終了時に元へ戻るため、シェル自身のスクリプト読み込みに影響しない。

```console
$ printf 'echo A\nread -r x < /dev/null || true\necho B\n' | bash
A
B
```

- メニューの入力を `read -r action_num < /dev/tty` に変更
- 各スクリプトへの受け渡しも `< /dev/tty` で行う
- 端末の有無は `tty_available` で持ち回る
- 端末が無い場合は `/dev/null` を渡す。残りのスクリプトを子プロセスに
  読ませないため

引数を渡す形式 (`... | bash -s -- update`) は fd 0 を触らないため影響を
受けておらず、今回の修正でも挙動は変わらない。

## 動作確認

`/dev/tty` を通常ファイルに置き換えた擬似端末で、修正前後を比較した。

**修正前** — バナーも出ず、擬似端末の内容がコマンドとして実行される

```
bash: line 72: 3: command not found
```

**修正後** — バナーからスクリプトの受け渡しまで正常に流れる

```
==================== gcp-minecraft ====================
Downloading ydak/gcp-minecraft (main) ...

-*-*-*-*- [ACTION (操作を選択)] -*-*-*-*-
[1] create (マインクラフトサーバーを作成)
[2] update (マインクラフトを更新)
[3] delete (マインクラフトサーバーを削除)
Select action (Default: 1): ==================== Start delete minecraft server  ====================
```

`3` を選択して `delete.sh` に渡り、標準入力も繋がっている
(`delete.sh` が gcloud を呼ぶところまで到達している)。

- `shellcheck -x` / `bash -n` 指摘なし

**未確認:** 実機の端末での動作。検証環境に `/dev/tty` が無いため擬似端末での
確認にとどまる。**前回この分岐が実行されず見落としたのが今回の原因**なので、
マージ後に CloudShell での実地確認をお願いしたい。

## 補足

回避策として、プロセス置換であれば修正前のコードでも動作する。
シェルがスクリプトを `/dev/fd/N` から読むため、fd 0 の差し替えが問題にならない。

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh)
```
