### PR TITLE
feat(create): 最大接続人数指定の実装

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -98,6 +98,24 @@ if [ "$permission_num" == "" ]; then permission_num=2 ; fi
 num_validation "$permission_num" 3
 permission=${permission_num_list[$permission_num-1]}
 
+# MAX PLAYERS ==========
+cat <<EOS
+
+-*-*-*-*- [MAX PLAYERS (同時に接続できる最大人数)] -*-*-*-*-
+無料枠の e2-micro はメモリが 1GB しかないため、3 人程度が実用上の上限です。
+それ以上で遊ぶ場合はマシンタイプの変更を検討して下さい。
+(The free tier e2-micro has only 1GB of memory, so around 3 players is the
+ practical limit. Consider a larger machine type if you need more.)
+EOS
+echo -n "Max players (Default: 2): "
+read -r max_players
+if [ "$max_players" == "" ]; then max_players=2 ; fi
+positive_num_validation "$max_players"
+if [ "$max_players" -ge 5 ]; then
+  echo "[WARN] $max_players players may not fit in 1GB of memory."
+  echo "       ($max_players 人はメモリ 1GB に収まらない可能性があります。)"
+fi
+
 # SEED ==========
 cat <<EOS
 
@@ -230,7 +248,7 @@ external_ip=$(gcloud compute instances create minecraft \
 mkdir /var/minecraft && \
 cd /var/minecraft/ && \
 docker volume create mc-volume && \
-docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e ALLOW_LIST=false -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
+docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e ALLOW_LIST=false -e MAX_PLAYERS=${max_players:-2} -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
 " | jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP')
 
 echo "Creating server complete!"

--- a/functions.sh
+++ b/functions.sh
@@ -21,6 +21,26 @@ function num_validation() {
 }
 
 ################################################################################
+# Receives a string and checks if it is a positive integer.
+# Used where the answer is not a menu choice, so num_validation, which only
+# accepts a single digit within a range, does not fit.
+# If it is not valid, exits with error code 1.
+#
+# Arguments:
+#   1: Received input
+# Returns:
+#   None
+################################################################################
+function positive_num_validation() {
+  local received=$1
+
+  if [[ ! ("$received" =~ ^[1-9][0-9]*$) ]]; then
+    echo "[ERROR] Enter a number of 1 or more. (1 以上の数字を入力して下さい。)"
+    exit 1
+  fi
+}
+
+################################################################################
 # Waits until the Bedrock server answers a RakNet unconnected ping.
 # Prints a dot every second while waiting.
 #


### PR DESCRIPTION
## 背景

`create.sh` が `MAX_PLAYERS` を指定していないため、Bedrock の既定値である
**10 人**のまま作成されていた。

無料枠の `e2-micro` はメモリが 1GB しかなく、サーバー本体だけで 400〜700MB 程度を使う。
プレイヤーが増えるほど、また離れた場所に散らばるほど読み込むチャンクが増えるため、
10 人は現実的な値ではない。

## 変更内容

他の設定と同じ体裁で、作成時に指定できるようにした。既定値は **2**。

```
-*-*-*-*- [MAX PLAYERS (同時に接続できる最大人数)] -*-*-*-*-
無料枠の e2-micro はメモリが 1GB しかないため、3 人程度が実用上の上限です。
それ以上で遊ぶ場合はマシンタイプの変更を検討して下さい。
(The free tier e2-micro has only 1GB of memory, so around 3 players is the
 practical limit. Consider a larger machine type if you need more.)
Max players (Default: 2):
```

- `docker run` に `-e MAX_PLAYERS=${max_players:-2}` を追加
- 5 人以上を指定した場合は警告を表示する (**停止はしない**。判断は利用者に委ねる)
- `positive_num_validation` を `functions.sh` に追加

### なぜ検証関数を追加したか

既存の `num_validation` は `^[1-$max_num]$` という正規表現で、
**1 桁かつ範囲内の選択肢**しか受け付けない。メニュー選択には適しているが、
`10` のような任意の正整数を受ける入力には使えない。

用途が異なるため既存の関数は変更せず、別の関数として追加した。

## 動作確認

| 入力 | 結果 |
|---|---|
| (空) | `MAX_PLAYERS=2` (既定値) |
| `1` | `MAX_PLAYERS=1` |
| `3` | `MAX_PLAYERS=3` |
| `10` | 警告を表示したうえで `MAX_PLAYERS=10` |
| `0` | エラーで停止 |
| `-1` | エラーで停止 |
| `abc` | エラーで停止 |
| `2.5` | エラーで停止 |

- `shellcheck -x` / `bash -n` 指摘なし

**未確認:** 実際に VM を作成して `max-players` が反映されるところまで。
環境変数名 `MAX_PLAYERS` はイメージのドキュメントで確認しているが、
実機での反映は未検証。

## 補足

既存のサーバーは作成済みのため、この変更では変わらない。
変更する場合は `server.properties` を直接書き換えて再起動する。

```bash
gcloud compute ssh minecraft --zone=us-west1-b \
  --command='docker exec mc-server sed -i "s/^max-players=.*/max-players=2/" /data/server.properties && docker restart mc-server'
```
