### PR TITLE
feat(backup): ワールドのバックアップと復元を追加

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -e
+
+script_dir=$(dirname "${0}")
+# shellcheck source=functions.sh
+. "$script_dir/functions.sh"
+
+ZONE=us-west1-b
+SERVER_NAME=minecraft
+BACKUP_DIR="$HOME"
+
+echo "==================== Start minecraft backup ===================="
+
+# GOOGLE CLOUD ==========
+echo -n "Setting Google Cloud info ..."
+project_id=$(gcloud config get project)
+project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
+gcloud config set project "$project_id"
+
+# A stopped instance has no external IP, so an empty value is also a failure.
+external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
+  --format="value(networkInterfaces[0].accessConfigs[0].natIP)" 2>/dev/null || true)
+
+if [ -z "$external_ip" ]; then
+  cat <<EOS
+
+[ERROR] Server '$SERVER_NAME' was not found in zone $ZONE, or it is not running.
+        (ゾーン $ZONE にサーバーが無いか、起動していません。)
+
+The current project is '$project_id'. Check that it is the right one.
+(現在のプロジェクトは '$project_id' です。対象が正しいか確認して下さい。)
+
+EOS
+  exit 1
+fi
+
+world_size=$(gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
+  --command="docker run --rm -v mc-volume:/data busybox du -sh /data/worlds 2>/dev/null | cut -f1" \
+  2>/dev/null || true)
+
+cat <<EOS
+
+-*-*-*-*- [バックアップ対象の確認] -*-*-*-*-
+プロジェクト ID
+　$project_id
+プロジェクト番号
+　$project_num
+サーバー名
+　$SERVER_NAME
+ワールドのサイズ
+　${world_size:-(取得できませんでした)}
+保存先
+　$BACKUP_DIR
+
+ワールドデータをバックアップします。
+書き込み途中のデータを掴まないよう、いったんサーバーを停止します。
+接続中のプレイヤーは全員切断されます。
+EOS
+
+echo -n "よろしいですか? [y/N]: "
+read -r backup_yn
+if [ "$backup_yn" != "y" ]; then exit 1 ; fi
+
+timestamp=$(date +%Y%m%d-%H%M%S)
+backup_file="${BACKUP_DIR}/minecraft-backup-${timestamp}.tar.gz"
+
+# Stop the server before reading the world. The Bedrock world is a LevelDB
+# directory, so archiving it mid-write can produce a backup that does not
+# restore. The image turns SIGTERM into a clean `stop`.
+echo "Stopping the server ..."
+gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server" > /dev/null
+
+echo "Downloading the world ..."
+
+# busybox is a couple of megabytes and is guaranteed to carry tar and sh, so it
+# is used rather than reaching into the volume's host path, which would need
+# sudo. The archive is streamed straight to CloudShell: no temporary file is
+# written on the instance, whose /tmp is RAM backed and whose disk is only 10GB.
+if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
+  --command="docker run --rm -v mc-volume:/data busybox tar cz -C /data worlds" \
+  > "$backup_file" 2>/dev/null; then
+  rm -f "$backup_file"
+  echo "[ERROR] Failed to download the world. (ワールドの取得に失敗しました。)"
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null || true
+  exit 1
+fi
+
+echo "Restarting the server ..."
+gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null
+
+# Reading the archive back decompresses every entry and checks the gzip CRC, so
+# this catches a truncated or corrupted transfer before it is trusted.
+echo "Verifying the archive ..."
+if ! tar tzf "$backup_file" > /dev/null 2>&1; then
+  rm -f "$backup_file"
+  echo "[ERROR] The archive is corrupted and has been discarded."
+  echo "        (アーカイブが壊れていたため破棄しました。)"
+  exit 1
+fi
+
+backup_size=$(du -h "$backup_file" | cut -f1)
+
+echo ""
+echo "Waiting for the Minecraft server to come back ..."
+echo -n "(マインクラフトサーバーの再起動を待っています) "
+
+if wait_for_server "$external_ip" 900; then
+  cat <<EOS
+
+Backup complete!
+ (バックアップが完了しました！)
+
+################################################################################
+${backup_file}
+${backup_size}
+################################################################################
+
+CloudShell のエディタからダウンロードできます。
+(Open the CloudShell editor and download the file to keep it off the instance.)
+
+復元するときは restore を選んで下さい。
+(Choose restore to put this world back.)
+
+EOS
+else
+  cat <<EOS
+
+[WARN] The backup was saved, but the server did not answer within 15 minutes.
+       (バックアップは保存できましたが、サーバーが 15 分以内に応答しませんでした。)
+
+################################################################################
+${backup_file}
+${backup_size}
+################################################################################
+
+Check the log with the following command.
+(下記でログを確認して下さい。)
+
+  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+
+EOS
+  exit 1
+fi
+
+echo "==================== End minecraft backup ===================="

--- a/mc.sh
+++ b/mc.sh
@@ -15,7 +15,7 @@ REPO="ydak/gcp-minecraft"
 REF="${REF:-main}"
 ACTION="${1:-}"
 
-action_list=(create update delete)
+action_list=(create update backup restore delete)
 
 usage() {
   cat <<EOS
@@ -23,15 +23,20 @@ Usage (CloudShell):
 
   curl -fsSL https://raw.githubusercontent.com/${REPO}/main/mc.sh | bash
 
-Then pick create / update / delete from the menu.
-(その後、メニューから create / update / delete を選択します。)
+Then pick what to do from the menu.
+(その後、メニューから操作を選択します。)
+
+  create   Create a Minecraft server (マインクラフトサーバーを作成)
+  update   Update Minecraft and the host (マインクラフトとホストを更新)
+  backup   Save the world to CloudShell (ワールドデータをバックアップ)
+  restore  Put a saved world back (ワールドデータを復元)
+  delete   Delete the server (マインクラフトサーバーを削除)
 
 An action can also be given directly, which skips the menu.
 (操作を引数で直接指定すると、メニューを省略できます。)
 
   ... | bash -s -- create
-  ... | bash -s -- update
-  ... | bash -s -- delete
+  ... | bash -s -- backup
 
 Set REF to use a branch or tag other than main.
 (REF を指定すると main 以外のブランチ・タグを利用できます。)
@@ -39,7 +44,7 @@ EOS
 }
 
 case "$ACTION" in
-  "" | create | update | delete) ;;
+  "" | create | update | backup | restore | delete) ;;
   -h | --help | help)
     usage
     exit 0
@@ -108,14 +113,16 @@ if [ "$ACTION" == "" ]; then
   cat <<EOS
 
 -*-*-*-*- [ACTION (操作を選択)] -*-*-*-*-
-[1] create (マインクラフトサーバーを作成)
-[2] update (マインクラフトを更新)
-[3] delete (マインクラフトサーバーを削除)
+[1] create  (マインクラフトサーバーを作成)
+[2] update  (マインクラフトとホストを更新)
+[3] backup  (ワールドデータをバックアップ)
+[4] restore (ワールドデータを復元)
+[5] delete  (マインクラフトサーバーを削除)
 EOS
   echo -n "Select action (Default: 1): "
   read -r action_num < /dev/tty
   if [ "$action_num" == "" ]; then action_num=1 ; fi
-  num_validation "$action_num" 3
+  num_validation "$action_num" 5
   ACTION=${action_list[$action_num-1]}
 fi
 

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -e
+
+script_dir=$(dirname "${0}")
+# shellcheck source=functions.sh
+. "$script_dir/functions.sh"
+
+ZONE=us-west1-b
+SERVER_NAME=minecraft
+BACKUP_DIR="$HOME"
+
+echo "==================== Start minecraft restore ===================="
+
+# GOOGLE CLOUD ==========
+echo -n "Setting Google Cloud info ..."
+project_id=$(gcloud config get project)
+project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
+gcloud config set project "$project_id"
+
+# A stopped instance has no external IP, so an empty value is also a failure.
+external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
+  --format="value(networkInterfaces[0].accessConfigs[0].natIP)" 2>/dev/null || true)
+
+if [ -z "$external_ip" ]; then
+  cat <<EOS
+
+[ERROR] Server '$SERVER_NAME' was not found in zone $ZONE, or it is not running.
+        (ゾーン $ZONE にサーバーが無いか、起動していません。)
+
+The current project is '$project_id'. Check that it is the right one.
+(現在のプロジェクトは '$project_id' です。対象が正しいか確認して下さい。)
+
+EOS
+  exit 1
+fi
+
+# BACKUP ==========
+# Globbing into an array rather than parsing ls, then reversing so the newest
+# backup is offered first.
+shopt -s nullglob
+backups=("$BACKUP_DIR"/minecraft-backup-*.tar.gz)
+shopt -u nullglob
+
+if [ ${#backups[@]} -eq 0 ]; then
+  cat <<EOS
+
+[ERROR] No backup was found in $BACKUP_DIR.
+        ($BACKUP_DIR にバックアップが見つかりませんでした。)
+
+Take one with backup first, or upload a .tar.gz named
+minecraft-backup-*.tar.gz through the CloudShell editor.
+(先に backup を実行するか、minecraft-backup-*.tar.gz という名前で
+ CloudShell にアップロードして下さい。)
+
+EOS
+  exit 1
+fi
+
+mapfile -t backups < <(printf '%s\n' "${backups[@]}" | sort -r)
+
+cat <<EOS
+
+-*-*-*-*- [BACKUP (復元するバックアップを選択)] -*-*-*-*-
+EOS
+i=1
+for b in "${backups[@]}"; do
+  echo "[$i] $(basename "$b") ($(du -h "$b" | cut -f1))"
+  i=$((i + 1))
+done
+
+echo -n "Select backup (Default: 1): "
+read -r backup_num
+if [ "$backup_num" == "" ]; then backup_num=1 ; fi
+positive_num_validation "$backup_num"
+if [ "$backup_num" -gt "${#backups[@]}" ]; then
+  echo "[ERROR] Enter a number from the list. (一覧にある番号を入力して下さい。)"
+  exit 1
+fi
+backup_file="${backups[$backup_num - 1]}"
+
+# Check the archive here rather than after the world has been replaced.
+echo "Verifying the archive ..."
+if ! tar tzf "$backup_file" > /dev/null 2>&1; then
+  echo "[ERROR] $(basename "$backup_file") is corrupted."
+  echo "        ($(basename "$backup_file") は壊れています。)"
+  exit 1
+fi
+
+cat <<EOS
+
+-*-*-*-*- [復元対象の確認] -*-*-*-*-
+プロジェクト ID
+　$project_id
+プロジェクト番号
+　$project_num
+サーバー名
+　$SERVER_NAME
+復元するファイル
+　$(basename "$backup_file")
+
+現在のワールドを、このバックアップの内容で置き換えます。
+今のワールドは worlds.previous として 1 世代だけ残ります。
+サーバーは一度停止し、接続中のプレイヤーは全員切断されます。
+EOS
+
+echo -n "よろしいですか? [y/N]: "
+read -r restore_yn
+if [ "$restore_yn" != "y" ]; then exit 1 ; fi
+
+echo "Stopping the server ..."
+gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server" > /dev/null
+
+echo "Uploading the world ..."
+
+# The archive is expanded into a scratch directory first and the current world
+# is only moved aside once that has succeeded. A truncated upload therefore
+# fails at tar, before anything has been destroyed. The previous world is kept
+# as worlds.previous so a restore of the wrong file can still be undone.
+restore_cmd='docker run --rm -i -v mc-volume:/data busybox sh -c "
+set -e
+rm -rf /data/.restore
+mkdir -p /data/.restore
+tar xz -C /data/.restore
+test -d /data/.restore/worlds
+rm -rf /data/worlds.previous
+if [ -d /data/worlds ]; then mv /data/worlds /data/worlds.previous; fi
+mv /data/.restore/worlds /data/worlds
+rm -rf /data/.restore
+"'
+
+if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="$restore_cmd" \
+  < "$backup_file" > /dev/null 2>&1; then
+  cat <<EOS
+
+[ERROR] Failed to restore the world. (ワールドの復元に失敗しました。)
+
+The current world was left untouched, since it is only moved aside after the
+archive has been expanded successfully.
+(アーカイブの展開に成功してから入れ替える作りのため、現在のワールドは
+ 変更されていません。)
+
+EOS
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null || true
+  exit 1
+fi
+
+echo "Restarting the server ..."
+gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null
+
+echo ""
+echo "Waiting for the Minecraft server to come back ..."
+echo -n "(マインクラフトサーバーの再起動を待っています) "
+
+if wait_for_server "$external_ip" 900; then
+  cat <<EOS
+
+Restore complete!
+ (復元が完了しました！)
+
+################################################################################
+${external_ip}
+################################################################################
+
+置き換える前のワールドは worlds.previous として残っています。
+(The world from before this restore is kept as worlds.previous.)
+
+EOS
+else
+  cat <<EOS
+
+[WARN] The server did not answer within 15 minutes.
+       (15分以内にサーバーが応答しませんでした。)
+
+Check the log with the following command.
+(下記でログを確認して下さい。)
+
+  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+
+EOS
+  exit 1
+fi
+
+echo "==================== End minecraft restore ===================="


### PR DESCRIPTION
## 背景

ワールドを保全する手段が無かった。`delete.sh` はブートディスクごと消すため復旧できず、
VM の障害でも同じことが起きる。

## 変更内容

メニューに `backup` と `restore` を追加した。

```
-*-*-*-*- [ACTION (操作を選択)] -*-*-*-*-
[1] create  (マインクラフトサーバーを作成)
[2] update  (マインクラフトとホストを更新)
[3] backup  (ワールドデータをバックアップ)
[4] restore (ワールドデータを復元)
[5] delete  (マインクラフトサーバーを削除)
```

保存先は CloudShell の `$HOME`。`minecraft-backup-<日時>.tar.gz` として置かれるので、
CloudShell のエディタから手元にダウンロードできる。

### backup.sh

**サーバーを停止してから固める。** Bedrock のワールドは LevelDB なので、
書き込み中に固めると復元できないアーカイブになる。

**インスタンス上に一時ファイルを作らない。** COS の `/tmp` は tmpfs でメモリを消費し、
ディスクも 10GB しかない。`tar` の出力を SSH 越しにそのまま CloudShell へ流している。

**取得後に `tar tzf` で検証する。** 全エントリを展開して gzip の CRC まで読むため、
転送が途中で切れていれば検出できる。壊れていた場合はファイルを破棄する。

### restore.sh

`$HOME` のバックアップを一覧表示して選ばせる。

```
-*-*-*-*- [BACKUP (復元するバックアップを選択)] -*-*-*-*-
[1] minecraft-backup-20260808-014500.tar.gz (12M)
[2] minecraft-backup-20260807-231200.tar.gz (11M)
Select backup (Default: 1):
```

**壊れたアーカイブで現在のワールドを失わないよう、二重に守っている。**

1. アップロード前に `tar tzf` で検証する
2. インスタンス側では作業用ディレクトリへ展開し、**成功してから入れ替える**

```sh
set -e
rm -rf /data/.restore
mkdir -p /data/.restore
tar xz -C /data/.restore
test -d /data/.restore/worlds
rm -rf /data/worlds.previous
if [ -d /data/worlds ]; then mv /data/worlds /data/worlds.previous; fi
mv /data/.restore/worlds /data/worlds
```

展開に失敗した時点で `set -e` が止めるため、`/data/worlds` には到達しない。
入れ替え前のワールドは `worlds.previous` として 1 世代残るので、
誤ったファイルを復元してしまっても戻せる。

### 共通

ボリュームの読み書きは busybox コンテナ経由で行う。ホスト側のパスを直接触ると
`sudo` が必要になるため。busybox は数 MB で `tar` と `sh` を確実に持っている。

## 動作確認

**復元処理を実際の tar で検証した。** 最も危険な箇所のため、破損データを 2 種類用意した。

| 入力 | インスタンス側の結果 | クライアント側の事前検証 |
| --- | --- | --- |
| 正常なアーカイブ | 入れ替え成功、旧ワールドは `worlds.previous` へ | 通過 |
| 完全なゴミ | exit 2、**現在のワールドは無傷** | 検出して停止 |
| 途中で切れたアーカイブ | exit 2、**現在のワールドは無傷** | 検出して停止 |

- メニューの選択ロジックを `1`〜`5` および空・`6`・`0`・`x` で確認
- `shellcheck -x` / `bash -n` 指摘なし

**未確認:** 実機での通し実行。バックアップの取得と復元は VM が必要なため未検証。
特に SSH 越しにバイナリを流す部分は、実際の転送で確認する必要がある
(取得後の `tar tzf` で壊れていれば検出できるようにはしてある)。

## 補足

### 下り通信を消費する

インスタンス → CloudShell はインターネット経由なので、**無料枠の 1GB/月を消費する。**
ワールドが 300MB なら 1 回で 3 割。月 1 回程度なら問題にならないが、
毎日取るなら同一リージョンの GCS へ直接置く方式に変えた方がよい。

### メニューの番号が変わる

`delete` が `3` から `5` に移動する。README と記事の記述もあわせて更新が必要。
引数で指定する形式 (`bash -s -- delete`) は名前指定なので影響しない。
