### PR TITLE
feat(backup): ダウンロードの自動起動と復元時のアップロード案内

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -100,6 +100,20 @@ fi
 
 backup_size=$(du -h "$backup_file" | cut -f1)
 
+# The archive only lives in CloudShell's home directory, which is itself
+# ephemeral, so hand it to the browser rather than leaving the user to find it
+# in the editor. `cloudshell download` asks the browser to start the download.
+# It is missing outside CloudShell, and a refused download should not fail the
+# backup, so neither case is treated as an error.
+if command -v cloudshell > /dev/null; then
+  echo "Starting the download ..."
+  echo "(ブラウザにダウンロードの確認が表示されます)"
+  cloudshell download "$backup_file" || true
+  download_started=1
+else
+  download_started=0
+fi
+
 echo ""
 echo "Waiting for the Minecraft server to come back ..."
 echo -n "(マインクラフトサーバーの再起動を待っています) "
@@ -115,13 +129,27 @@ ${backup_file}
 ${backup_size}
 ################################################################################
 
-CloudShell のエディタからダウンロードできます。
-(Open the CloudShell editor and download the file to keep it off the instance.)
-
 復元するときは restore を選んで下さい。
 (Choose restore to put this world back.)
 
 EOS
+
+  if [ "$download_started" == "1" ]; then
+    cat <<EOS
+ブラウザでのダウンロードを開始しました。
+確認が出ていない場合は、下記でやり直せます。
+(The download has been handed to the browser. Run this again if nothing appeared.)
+
+  cloudshell download ${backup_file}
+
+EOS
+  else
+    cat <<EOS
+CloudShell 以外で実行しているため、自動ダウンロードは行いません。
+(Not running in CloudShell, so the download was not started.)
+
+EOS
+  fi
 else
   cat <<EOS
 


### PR DESCRIPTION
## 背景

`backup` は保存先のパスを案内するだけで終わっており、手元に落とすには
CloudShell のエディタを開いて自分でダウンロードする必要があった。

```
################################################################################
/home/user/minecraft-backup-20260808-020000.tar.gz
12M
################################################################################

CloudShell のエディタからダウンロードできます。
```

アーカイブは CloudShell のホームにしか無く、**そのホーム自体も永続的ではない**。
手元に落とすところまでを一連の流れに含めるべきだった。

## 変更内容

CloudShell には download を起動するコマンドが用意されている。

> The `download-files` command (with alternative names: `download-file`,
> `download`, `dl`) is used to initiate the download of the specified file.

これを呼び、ブラウザ側でダウンロードが始まるようにした。

```bash
cloudshell download "$backup_file"
```

**アーカイブの検証後、サーバーの復帰を待つ前に呼んでいる。** 待ち時間の間に
ダウンロードが進むため、体感の待ちが増えない。

### 失敗しても止めない

| 状況 | 挙動 |
| --- | --- |
| CloudShell 上 | ダウンロードを開始し、やり直し用のコマンドも表示する |
| CloudShell 以外 | `cloudshell` が無いので、その旨を表示してパスの案内のみ |
| ダウンロードが拒否された | バックアップ自体は成功しているので、失敗として扱わない |

バックアップは既に取得・検証まで終わっている。ダウンロードの成否で
スクリプト全体を失敗させるのは筋が悪いので、いずれも継続する。

## 動作確認

`cloudshell` をモックして 3 パターンを確認した。

| 状況 | 結果 |
| --- | --- |
| `cloudshell` あり | download を呼び、開始した旨を表示 |
| `cloudshell` なし | 呼ばず、CloudShell 以外である旨を表示 |
| `cloudshell` が exit 1 | 継続し、終了コード 0 |

- `shellcheck -x` / `bash -n` 指摘なし

**未確認:** 実機での動作。実際にブラウザのダウンロード確認が出るところは未検証。

## 補足

復元側 (`restore`) のアップロードは CloudShell のエディタから行う想定のまま。
`cloudshell` コマンドにアップロードに相当するものは無い。

---

## 追記: 復元側のアップロードについて

`restore` の一覧はホームディレクトリのファイルだけを拾うため、
手元の PC にあるバックアップをどう持ち込むかが分からなかった。

**アップロードを起動する仕組みは存在しない。** `cloudshell` コマンドの
サブコマンドは `help` / `edit-files` / `download-files` の 3 つのみで、
`download` と対になるものが無い。

> Files and folders can only be uploaded to and downloaded from your home directory.

コマンドラインからの手段としては `gcloud cloud-shell scp` があるが、
これは手元の PC のターミナルで実行するもので、CloudShell 内で動く
スクリプトからは呼べない。

そのため案内で補った。一覧の下と、バックアップが 1 つも無い場合のエラーに、
それぞれ手順を表示する。

- CloudShell の [ ⋮ ] メニューから Upload する手順
- `minecraft-backup-*.tar.gz` という命名が必要であること
- 手元の PC から `gcloud cloud-shell scp` で送る方法

**ダウンロードは自動化できるがアップロードはできない**という非対称は、
CloudShell 側の制約であり回避できない。
