### PR TITLE
docs(restore): 手元のファイルを持ち込む手順を案内する

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -47,10 +47,23 @@ if [ ${#backups[@]} -eq 0 ]; then
 [ERROR] No backup was found in $BACKUP_DIR.
         ($BACKUP_DIR にバックアップが見つかりませんでした。)
 
-Take one with backup first, or upload a .tar.gz named
-minecraft-backup-*.tar.gz through the CloudShell editor.
-(先に backup を実行するか、minecraft-backup-*.tar.gz という名前で
- CloudShell にアップロードして下さい。)
+先に backup を実行するか、手元のファイルをアップロードして下さい。
+(Take one with backup first, or upload one from your machine.)
+
+手元のファイルを使う場合:
+(To use a file from your machine:)
+
+  1. CloudShell 右上の [ ⋮ ] から Upload を選ぶ
+     (Click the [ more_vert ] menu in CloudShell and choose Upload)
+  2. ホームディレクトリにアップロードする
+     (Upload it to your home directory)
+  3. 名前を minecraft-backup-*.tar.gz に合わせる
+     (Name it minecraft-backup-*.tar.gz)
+
+手元の PC のターミナルからでも送れます。
+(It can also be pushed from a terminal on your machine.)
+
+  gcloud cloud-shell scp localhost:~/minecraft-backup-YYYYmmdd-HHMMSS.tar.gz cloudshell:~/
 
 EOS
   exit 1
@@ -67,6 +80,14 @@ for b in "${backups[@]}"; do
   echo "[$i] $(basename "$b") ($(du -h "$b" | cut -f1))"
   i=$((i + 1))
 done
+
+cat <<EOS
+
+手元のファイルを使う場合は、CloudShell 右上の [ ⋮ ] から Upload で
+ホームディレクトリへ置き、minecraft-backup-*.tar.gz という名前にして下さい。
+(To use a file from your machine, upload it to your home directory via the
+ [ more_vert ] menu and name it minecraft-backup-*.tar.gz.)
+EOS
 
 echo -n "Select backup (Default: 1): "
 read -r backup_num


### PR DESCRIPTION
## 背景

`restore` の一覧はホームディレクトリのファイルだけを拾うため、
**手元の PC にあるバックアップをどう持ち込むかが分からなかった。**

```
-*-*-*-*- [BACKUP (復元するバックアップを選択)] -*-*-*-*-
[1] minecraft-backup-20260807-164528.tar.gz (60K)
[2] minecraft-backup-20260807-163941.tar.gz (64K)
Select backup (Default: 1):
```

`backup` 側は #22 でブラウザへのダウンロードを自動で開始するようにしたが、
その逆方向にあたる仕組みは存在しない。

## アップロードは自動化できない

`cloudshell` コマンドのサブコマンドは以下の 3 つのみで、
`download-files` と対になるものが無い。

| サブコマンド | 用途 |
| --- | --- |
| `help` | ヘルプ |
| `edit-files` | エディタでファイルを開く |
| `download-files` | ダウンロードを開始する |

> Files and folders can only be uploaded to and downloaded from your home directory.

コマンドラインからの手段としては `gcloud cloud-shell scp` があるが、
これは**手元の PC のターミナルで実行して送り込む**ものであり、
CloudShell 内で動くスクリプトからは呼べない。

**ダウンロードは自動化できるがアップロードはできない**という非対称は
CloudShell 側の制約であり、回避できない。

## 変更内容

案内で補う。2 箇所に表示する。

**一覧の下**

```
[1] minecraft-backup-20260807-164528.tar.gz (60K)
[2] minecraft-backup-20260807-163941.tar.gz (64K)

手元のファイルを使う場合は、CloudShell 右上の [ ⋮ ] から Upload で
ホームディレクトリへ置き、minecraft-backup-*.tar.gz という名前にして下さい。

Select backup (Default: 1):
```

**バックアップが 1 つも無い場合のエラー**

手順を番号付きで示し、`gcloud cloud-shell scp` の例も添える。
命名規則に合っていないと一覧に出ないため、その点を明示している。

## 動作確認

- 一覧表示部分を実際のファイル名で再現し、表示崩れがないことを確認
- `shellcheck -x` / `bash -n` 指摘なし

表示の変更のみで、処理には手を入れていない。

## 経緯

この変更は #22 に含めるつもりだったが、`backup.sh` のみがマージされた時点で
ブランチが自動削除され、後から push した分が取り残されていた。
main から切り直して出し直したもの。
