### PR TITLE
feat(mc): 短縮 URL 、操作記述漏れ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Internally, this uses a Docker container.
 1. Execute the following command
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash
+curl -fsSL https://daylifehack.com/mc | bash
 ```
 
 1. Select what you want to do from the menu
@@ -40,7 +40,14 @@ Select action (Default: 1):
 The action can also be given directly, which skips the menu.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash -s -- update
+curl -fsSL https://daylifehack.com/mc | bash -s -- update
+```
+
+`https://daylifehack.com/mc` redirects to `mc.sh` in this repository.
+The direct URL also works if you prefer it.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash
 ```
 
 ## Notes

--- a/mc.sh
+++ b/mc.sh
@@ -2,7 +2,11 @@
 #
 # Bootstrap for gcp-minecraft.
 #
-#   curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash
+#   curl -fsSL https://daylifehack.com/mc | bash
+#
+# That URL is a redirect to this file on raw.githubusercontent.com. Going
+# through it keeps the published command short and lets the target be
+# repointed later without reprinting the command everywhere.
 #
 # The scripts in this repository source functions.sh and const.sh from their own
 # directory, so a single file cannot be piped straight into a shell. This
@@ -21,7 +25,7 @@ usage() {
   cat <<EOS
 Usage (CloudShell):
 
-  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/mc.sh | bash
+  curl -fsSL https://daylifehack.com/mc | bash
 
 Then pick what to do from the menu.
 (その後、メニューから操作を選択します。)
@@ -51,7 +55,8 @@ case "$ACTION" in
     ;;
   *)
     echo "[ERROR] Unknown action: $ACTION"
-    echo "        (不明な操作です。create / update / delete のいずれかを指定して下さい。)"
+    echo "        (不明な操作です。create / update / backup / restore / delete の"
+    echo "         いずれかを指定して下さい。)"
     echo ""
     usage
     exit 1


### PR DESCRIPTION
## 背景

実行コマンドが 63 文字と長く、記事に載せるにも口頭で伝えるにも扱いづらかった。

```bash
curl -fsSL https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh | bash
```

`daylifehack.com/mc` から `mc.sh` へのリダイレクトを設置したので、
そちらを案内に使うようにした。**40 文字**になる。

```bash
curl -fsSL https://daylifehack.com/mc | bash
```

## 変更内容

### 短縮 URL に切り替え

`mc.sh` の usage とヘッダコメント、README の実行例を差し替えた。
README には直接の URL も併記し、リダイレクトが使えない場合の逃げ道を残している。

**リダイレクトは 302 にしてある。** 301 だとブラウザが永続的にキャッシュするため、
将来リダイレクト先を変更しても古い先に留まり続ける。
案内済みのコマンドを書き換えずに配布物を切り替えられる余地を残した。

### 操作一覧の記述漏れを修正

不明な操作を指定した際のエラーが古いままだった。
`backup` と `restore` を追加した際にメニューと `case` 文は更新したが、
**このメッセージを見落としていた。**

```diff
-        (不明な操作です。create / update / delete のいずれかを指定して下さい。)
+        (不明な操作です。create / update / backup / restore / delete の
+         いずれかを指定して下さい。)
```

## 動作確認

**リダイレクトを実機で検証済み。**

```console
$ curl -sIL https://daylifehack.com/mc
HTTP/1.1 302 Found
location: https://raw.githubusercontent.com/ydak/gcp-minecraft/main/mc.sh
HTTP/1.1 200 OK
```

| 確認項目 | 結果 |
| --- | --- |
| 短縮 URL の内容が本家と一致するか | **バイト単位で完全一致** |
| 末尾スラッシュ `/mc/` | 同じ内容が返る |
| パイプ実行 `\| bash -s -- --help` | 正常に動作 |
| 5 つの操作すべてが `case` で受理されるか | create / update / backup / restore / delete すべて受理、不正値は拒否 |
| `shellcheck -x` / `bash -n` | 指摘なし |

## 補足

リダイレクトはリポジトリ外 (`daylifehack.com` の `.htaccess`) にあるため、
この repository だけでは完結しない。リダイレクトが失われると短縮 URL は動かなくなる。
README に直接の URL を残しているのはそのため。
