### PR TITLE
feat(ui): 出力を一般利用者向けに整理し、サーバー情報を配布できるようにする

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -12,7 +12,7 @@ BACKUP_DIR="$HOME"
 echo "==================== ワールドのバックアップ ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認しています ... "
+echo -n "確認中 ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
 gcloud config set project "$project_id" > /dev/null
@@ -69,10 +69,10 @@ backup_file="${BACKUP_DIR}/minecraft-backup-${timestamp}.tar.gz"
 # directory, so archiving it mid-write can produce a backup that does not
 # restore. The image turns SIGTERM into a clean `stop`.
 echo ""
-run_step "サーバーの停止" \
+run_step "サーバーの停止中" \
   gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo -n "  ワールドの取得 ... "
+echo -n "  ワールドの取得中 ... "
 
 # busybox is a couple of megabytes and is guaranteed to carry tar and sh, so it
 # is used rather than reaching into the volume's host path, which would need
@@ -89,12 +89,12 @@ if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
 fi
 
 echo "完了"
-run_step "サーバーの再開" \
+run_step "サーバーの再開中" \
   gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 # Reading the archive back decompresses every entry and checks the gzip CRC, so
 # this catches a truncated or corrupted transfer before it is trusted.
-echo -n "  データの検証 ... "
+echo -n "  データの検証中 ... "
 if ! tar tzf "$backup_file" > /dev/null 2>&1; then
   rm -f "$backup_file"
   echo "失敗"
@@ -119,7 +119,7 @@ else
 fi
 
 echo ""
-echo -n "マインクラフトの再開を待っています "
+echo -n "マインクラフト再開中 "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS

--- a/backup.sh
+++ b/backup.sh
@@ -9,13 +9,14 @@ ZONE=us-west1-b
 SERVER_NAME=minecraft
 BACKUP_DIR="$HOME"
 
-echo "==================== Start minecraft backup ===================="
+echo "==================== ワールドのバックアップ ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "Setting Google Cloud info ..."
+echo -n "確認しています ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id"
+gcloud config set project "$project_id" > /dev/null
+echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -67,10 +68,11 @@ backup_file="${BACKUP_DIR}/minecraft-backup-${timestamp}.tar.gz"
 # Stop the server before reading the world. The Bedrock world is a LevelDB
 # directory, so archiving it mid-write can produce a backup that does not
 # restore. The image turns SIGTERM into a clean `stop`.
-echo "Stopping the server ..."
-gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server" > /dev/null
+echo ""
+run_step "サーバーの停止" \
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo "Downloading the world ..."
+echo -n "  ワールドの取得 ... "
 
 # busybox is a couple of megabytes and is guaranteed to carry tar and sh, so it
 # is used rather than reaching into the volume's host path, which would need
@@ -80,21 +82,23 @@ if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
   --command="docker run --rm -v mc-volume:/data busybox tar cz -C /data worlds" \
   > "$backup_file" 2>/dev/null; then
   rm -f "$backup_file"
-  echo "[ERROR] Failed to download the world. (ワールドの取得に失敗しました。)"
+  echo "失敗"
+  echo "[ERROR] ワールドを取得できませんでした。"
   gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null || true
   exit 1
 fi
 
-echo "Restarting the server ..."
-gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null
+echo "完了"
+run_step "サーバーの再開" \
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 # Reading the archive back decompresses every entry and checks the gzip CRC, so
 # this catches a truncated or corrupted transfer before it is trusted.
-echo "Verifying the archive ..."
+echo -n "  データの検証 ... "
 if ! tar tzf "$backup_file" > /dev/null 2>&1; then
   rm -f "$backup_file"
-  echo "[ERROR] The archive is corrupted and has been discarded."
-  echo "        (アーカイブが壊れていたため破棄しました。)"
+  echo "失敗"
+  echo "[ERROR] データが壊れていたため破棄しました。"
   exit 1
 fi
 
@@ -106,8 +110,8 @@ backup_size=$(du -h "$backup_file" | cut -f1)
 # It is missing outside CloudShell, and a refused download should not fail the
 # backup, so neither case is treated as an error.
 if command -v cloudshell > /dev/null; then
-  echo "Starting the download ..."
-  echo "(ブラウザにダウンロードの確認が表示されます)"
+  echo "完了"
+  echo "ブラウザにダウンロードの確認が表示されます。"
   cloudshell download "$backup_file" || true
   download_started=1
 else
@@ -115,14 +119,12 @@ else
 fi
 
 echo ""
-echo "Waiting for the Minecraft server to come back ..."
-echo -n "(マインクラフトサーバーの再起動を待っています) "
+echo -n "マインクラフトの再開を待っています "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS
 
-Backup complete!
- (バックアップが完了しました！)
+バックアップが完了しました！
 
 ################################################################################
 ${backup_file}
@@ -170,4 +172,3 @@ EOS
   exit 1
 fi
 
-echo "==================== End minecraft backup ===================="

--- a/backup.sh
+++ b/backup.sh
@@ -13,9 +13,9 @@ echo "==================== ワールドのバックアップ ===================
 
 # GOOGLE CLOUD ==========
 echo -n "確認中 ... "
-project_id=$(gcloud config get project)
+project_id=$(gcloud config get project 2> /dev/null)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null
+gcloud config set project "$project_id" > /dev/null 2>&1
 echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
@@ -35,9 +35,20 @@ EOS
   exit 1
 fi
 
-world_size=$(gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
+# The first `gcloud compute ssh` in a fresh CloudShell generates an SSH key.
+# Without --quiet it stops on a confirmation prompt, and with stderr discarded
+# that prompt is invisible, so the script looks like it has hung. --quiet
+# answers it, and the dots show that something is still happening: key
+# generation and the first connection together take the best part of a minute.
+echo -n "  サーバーへ接続中 "
+size_out=$(mktemp)
+gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" \
   --command="docker run --rm -v mc-volume:/data busybox du -sh /data/worlds 2>/dev/null | cut -f1" \
-  2>/dev/null || true)
+  > "$size_out" 2>/dev/null &
+wait_with_dots $! || true
+world_size=$(cat "$size_out" 2>/dev/null || true)
+rm -f "$size_out"
+echo " 完了"
 
 cat <<EOS
 
@@ -70,27 +81,32 @@ backup_file="${BACKUP_DIR}/minecraft-backup-${timestamp}.tar.gz"
 # restore. The image turns SIGTERM into a clean `stop`.
 echo ""
 run_step "サーバーの停止中" \
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo -n "  ワールドの取得中 ... "
+echo -n "  ワールドの取得中 "
 
 # busybox is a couple of megabytes and is guaranteed to carry tar and sh, so it
 # is used rather than reaching into the volume's host path, which would need
 # sudo. The archive is streamed straight to CloudShell: no temporary file is
 # written on the instance, whose /tmp is RAM backed and whose disk is only 10GB.
-if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
+gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" \
   --command="docker run --rm -v mc-volume:/data busybox tar cz -C /data worlds" \
-  > "$backup_file" 2>/dev/null; then
+  > "$backup_file" 2>/dev/null &
+
+download_status=0
+wait_with_dots $! || download_status=$?
+
+if [ "$download_status" -ne 0 ]; then
   rm -f "$backup_file"
-  echo "失敗"
+  echo " 失敗"
   echo "[ERROR] ワールドを取得できませんでした。"
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null || true
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null 2>&1 || true
   exit 1
 fi
 
-echo "完了"
+echo " 完了"
 run_step "サーバーの再開中" \
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 # Reading the archive back decompresses every entry and checks the gzip CRC, so
 # this catches a truncated or corrupted transfer before it is trusted.
@@ -166,7 +182,7 @@ ${backup_size}
 Check the log with the following command.
 (下記でログを確認して下さい。)
 
-  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+  gcloud compute ssh --quiet $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
 
 EOS
   exit 1

--- a/backup.sh
+++ b/backup.sh
@@ -12,11 +12,37 @@ BACKUP_DIR="$HOME"
 echo "==================== ワールドのバックアップ ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認中 ... "
-project_id=$(gcloud config get project 2> /dev/null)
-project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null 2>&1
-echo "完了"
+# Run in the background so the dots reflect real elapsed time rather than
+# being three characters printed up front.
+# Declared up front: they are assigned by sourcing the file the subshell
+# writes, which neither shellcheck nor set -e can see into.
+project_id=""
+project_num=""
+echo -n "確認中 "
+gcloud_info=$(mktemp)
+(
+  pid=$(gcloud config get project 2> /dev/null)
+  pnum=$(gcloud projects describe "$pid" --format="value(projectNumber)" 2> /dev/null)
+  gcloud config set project "$pid" > /dev/null 2>&1
+  printf 'project_id=%q\nproject_num=%q\n' "$pid" "$pnum"
+) > "$gcloud_info" 2> /dev/null &
+wait_with_dots $! || true
+# shellcheck disable=SC1090
+. "$gcloud_info"
+rm -f "$gcloud_info"
+if [ -z "$project_id" ]; then
+  echo " 失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud のプロジェクトを取得できませんでした。
+        下記で対象を指定してから、もう一度お試しください。
+
+  gcloud config set project <プロジェクト ID>
+
+EOS
+  exit 1
+fi
+echo " 完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -110,13 +136,18 @@ run_step "サーバーの再開中" \
 
 # Reading the archive back decompresses every entry and checks the gzip CRC, so
 # this catches a truncated or corrupted transfer before it is trusted.
-echo -n "  データの検証中 ... "
-if ! tar tzf "$backup_file" > /dev/null 2>&1; then
+echo -n "  データの検証中 "
+tar tzf "$backup_file" > /dev/null 2>&1 &
+verify_status=0
+wait_with_dots $! || verify_status=$?
+
+if [ "$verify_status" -ne 0 ]; then
   rm -f "$backup_file"
-  echo "失敗"
+  echo " 失敗"
   echo "[ERROR] データが壊れていたため破棄しました。"
   exit 1
 fi
+echo " 完了"
 
 backup_size=$(du -h "$backup_file" | cut -f1)
 
@@ -126,7 +157,6 @@ backup_size=$(du -h "$backup_file" | cut -f1)
 # It is missing outside CloudShell, and a refused download should not fail the
 # backup, so neither case is treated as an error.
 if command -v cloudshell > /dev/null; then
-  echo "完了"
   echo "ブラウザにダウンロードの確認が表示されます。"
   cloudshell download "$backup_file" || true
   download_started=1

--- a/create.sh
+++ b/create.sh
@@ -11,12 +11,12 @@ echo "==================== Minecraft サーバーの作成 ===================="
 
 # GOOGLE CLOUD ==========
 echo -n "確認中 ... "
-project_id=$(gcloud config get project)
+project_id=$(gcloud config get project 2> /dev/null)
 # NOTE: `gcloud projects list --filter="$project_id"` is a bare-word filter that
 #       matches ANY field. A similarly named project makes it return multiple
 #       lines, which silently corrupts the service account name below.
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null
+gcloud config set project "$project_id" > /dev/null 2>&1
 echo "完了"
 
 cat <<EOS
@@ -488,7 +488,7 @@ The VM itself was created, so the container may still be starting.
 Check the log with the following command.
 (VM の作成は完了しています。コンテナ起動中の可能性があるためログを確認して下さい。)
 
-  gcloud compute ssh minecraft --zone=us-west1-b --command='docker logs mc-server | tail -30'
+  gcloud compute ssh --quiet minecraft --zone=us-west1-b --command='docker logs mc-server | tail -30'
 
 ################################################################################
 ${external_ip}

--- a/create.sh
+++ b/create.sh
@@ -327,24 +327,113 @@ echo "完了"
 echo ""
 echo -n "マインクラフトの起動を待っています "
 
-if wait_for_server "$external_ip" 900; then
+ping_info=$(mktemp)
+
+if wait_for_server "$external_ip" 900 "$ping_info"; then
+  # The server reports its own name and version, so take them from there rather
+  # than from what was typed: this is what a client will actually see.
+  MC_VERSION=""
+  if [ -s "$ping_info" ]; then
+    # shellcheck disable=SC1090
+    . "$ping_info"
+  fi
+  rm -f "$ping_info"
+
+  # Everything needed to join, and to manage the server later, gathered in one
+  # place. CloudShell's home directory is not permanent, so the file is handed
+  # to the browser as well.
+  info_file="${HOME}/minecraft-server-info.txt"
+  cat > "$info_file" <<EOS
+====================================================================
+ Minecraft サーバー情報
+====================================================================
+ 作成日時 : $(date '+%Y-%m-%d %H:%M:%S %Z')
+
+--------------------------------------------------------------------
+ 接続情報   ※ 一緒に遊ぶ人に伝える内容
+--------------------------------------------------------------------
+ サーバーアドレス : ${external_ip}
+ ポート           : 19132
+ サーバー名       : ${server_name:-ydak}
+ エディション     : 統合版 (Bedrock)
+ バージョン       : ${MC_VERSION:-(取得できませんでした)}
+
+--------------------------------------------------------------------
+ ゲーム設定
+--------------------------------------------------------------------
+ ゲームモード : ${game_mode:-survival}
+ 難易度       : ${difficulty:-normal}
+ チート       : ${allow_cheat:-false}
+ 参加者の権限 : ${permission:-member}
+ 最大人数     : ${max_players:-2}
+ シード値     : ${seed:-(ランダム)}
+
+--------------------------------------------------------------------
+ 管理情報   ※ 自分用。共有する必要はありません
+--------------------------------------------------------------------
+ プロジェクト ID  : ${project_id}
+ プロジェクト番号 : ${project_num}
+ インスタンス名   : minecraft
+ ゾーン           : us-west1-b
+ マシンタイプ     : e2-micro
+
+--------------------------------------------------------------------
+ 操作方法
+--------------------------------------------------------------------
+ CloudShell で下記を実行し、メニューから選びます。
+
+   curl -fsSL https://daylifehack.com/mc | bash
+
+   create  : サーバーを作成する
+   update  : マインクラフトとホストを更新する
+   backup  : ワールドをバックアップする
+   restore : ワールドを復元する
+   delete  : サーバーを削除する (ワールドも消えます)
+
+--------------------------------------------------------------------
+ 注意
+--------------------------------------------------------------------
+ ・許可リストは無効です。この IP を知っていれば誰でも参加できます。
+ ・サーバーを停止・起動すると IP アドレスが変わります。
+   再起動 (reboot) では変わりません。
+ ・無料枠で動かせるサーバーは 1 台までです。
+ ・下り通信は 1GB/月 まで無料です。超過分は約 \$0.12/GB です。
+   目安として 1 人が 1 時間遊ぶとおよそ 36MB です。
+====================================================================
+EOS
+
   cat <<EOS
 
-All Done!!
- (すべて完了しました！！)
-
-You can access Minecraft using the following IP address!
-(下記のIPアドレスを使用してあなたのマインクラフトにアクセスしましょう！)
+すべて完了しました！
 
 ################################################################################
 ${external_ip}
 ################################################################################
 
-NOTE: The allow list is disabled, so anyone who knows this IP address can join.
-      (許可リストは無効です。この IP アドレスを知っていれば誰でも参加できます。)
+ ポート : 19132
+ 上記のアドレスとポートで、マインクラフトから接続できます。
+
+ 許可リストは無効です。この IP を知っていれば誰でも参加できます。
 
 EOS
+
+  # `cloudshell download` is missing outside CloudShell, and a refused download
+  # should not fail a successful build, so neither case is treated as an error.
+  if command -v cloudshell > /dev/null; then
+    cat <<EOS
+接続情報を ${info_file} に保存しました。
+ブラウザにダウンロードの確認が表示されます。
+
+EOS
+    cloudshell download "$info_file" || true
+  else
+    cat <<EOS
+接続情報を ${info_file} に保存しました。
+
+EOS
+  fi
 else
+  rm -f "$ping_info"
   cat <<EOS
 
 [WARN] The server did not answer within 15 minutes.

--- a/create.sh
+++ b/create.sh
@@ -7,16 +7,17 @@ script_dir=$(dirname "${0}")
 # shellcheck source=const.sh
 . "$script_dir/const.sh"
 
-echo "==================== Start create minecraft server  ===================="
+echo "==================== Minecraft サーバーの作成 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "Setting Google Cloud info ..."
+echo -n "確認しています ... "
 project_id=$(gcloud config get project)
 # NOTE: `gcloud projects list --filter="$project_id"` is a bare-word filter that
 #       matches ANY field. A similarly named project makes it return multiple
 #       lines, which silently corrupts the service account name below.
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id"
+gcloud config set project "$project_id" > /dev/null
+echo "完了"
 
 cat <<EOS
 
@@ -133,26 +134,32 @@ if [ "$seed" != "" ]; then
   fi
 fi
 
-echo "Configuration is OK. The next step is to create a minecraft server."
-echo "(サーバー設定が完了しました。マインクラフトサーバーの作成を開始します。)"
+cat <<EOS
 
-echo "Enabling compute.googleapis.com ..."
+設定が完了しました。サーバーを作成します。数分かかります。
+(Configuration is complete. Creating the server. This takes a few minutes.)
+
+EOS
+
 # NOTE: enabling an API counts against the serviceusage "Mutate requests per
 #       minute" quota. Hitting it fails the whole script under `set -e`, so
 #       retry with a wait longer than the one-minute quota window.
 #       A missing billing account is a precondition failure, not a rate limit,
 #       so retrying never clears it. Bail out immediately in that case.
-#       Stream the output through tee rather than capturing it silently:
-#       enabling the API takes a few minutes and gcloud's own progress output
-#       is the only sign that anything is happening.
+#       The output is captured rather than shown: it is a progress spinner and
+#       an operation id, neither of which is worth reading unless it fails.
 enable_log=$(mktemp)
+echo -n "  Google Cloud の準備 ... "
 for i in 1 2 3 4 5; do
-  gcloud services enable compute.googleapis.com 2>&1 | tee "$enable_log"
-  enable_status=${PIPESTATUS[0]}
+  gcloud services enable compute.googleapis.com > "$enable_log" 2>&1
+  enable_status=$?
   if [ "$enable_status" -eq 0 ]; then break; fi
+
+  if [ "${MC_VERBOSE:-0}" == "1" ]; then cat "$enable_log"; fi
 
   if grep -qE 'billing-enabled|UREQ_PROJECT_BILLING_NOT_FOUND|Billing account for project' "$enable_log"; then
     rm -f "$enable_log"
+    echo "失敗"
     cat <<EOS
 
 [ERROR] Billing is not enabled for this project.
@@ -171,8 +178,7 @@ EOS
     exit 1
   fi
 
-  echo "  Failed. Retrying in 70s ... ($i/5)"
-  echo "  (失敗しました。70秒待って再試行します)"
+  echo -n "再試行しています ($i/5) "
   sleep 70
 done
 rm -f "$enable_log"
@@ -180,31 +186,34 @@ rm -f "$enable_log"
 if ! gcloud services list --enabled \
   --filter="config.name=compute.googleapis.com" \
   --format="value(config.name)" | grep -q .; then
-  echo "[ERROR] Failed to enable compute.googleapis.com."
-  echo "        (API の有効化に失敗しました。数分置いて再実行して下さい。)"
+  echo "失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud の準備に失敗しました。
+        数分おいて、もう一度お試しください。
+        (Failed to enable compute.googleapis.com.)
+
+EOS
   exit 1
 fi
 
 # The default compute service account is created when the API is enabled.
 # Creating an instance before it exists fails, so wait for it to show up.
-echo -n "Waiting for the default service account ..."
 for i in $(seq 1 20); do
   if gcloud iam service-accounts describe \
     "$project_num-compute@developer.gserviceaccount.com" >/dev/null 2>&1; then
     break
   fi
-  echo -n "."
   sleep 15
 done
-echo ""
+echo "完了"
 
 # firewall =====================================================================
-echo "Checking Firewall ..."
 fw_minecraft=$(gcloud compute firewall-rules list --format="json" | jq -r '.[] | select(.name=="minecraft")')
 
 if [ -z "$fw_minecraft" ]; then
-  echo "Firewall minecraft is not found. Creating Firewall for Minecraft ..."
-  gcloud compute --project="$project_id" \
+  run_step "ネットワークの設定" \
+    gcloud compute --project="$project_id" \
     firewall-rules create minecraft \
     --description=minecraft \
     --direction=INGRESS \
@@ -215,10 +224,8 @@ if [ -z "$fw_minecraft" ]; then
     --source-ranges=0.0.0.0/0 \
     --target-tags=minecraft
 fi
-echo "Firewall creation complete!"
 
 # GCE ==========================================================================
-echo "Checking latest COS image ..."
 # NOTE: `test("cos-stable")` is a substring regex over every public image
 #       family, so it returns multiple lines the moment another family
 #       containing that string appears. describe-from-family is exact.
@@ -226,13 +233,15 @@ image=$(gcloud compute images describe-from-family cos-stable \
   --project=cos-cloud --format="value(selfLink)" | sed -E 's|.*/compute/v1/||')
 
 if [ -z "$image" ]; then
-  echo "[ERROR] Failed to resolve the latest COS image."
-  echo "        (COS イメージの取得に失敗しました。)"
+  cat <<EOS
+
+[ERROR] サーバーの土台となるイメージを取得できませんでした。
+        数分おいて、もう一度お試しください。
+        (Failed to resolve the latest COS image.)
+
+EOS
   exit 1
 fi
-echo "COS image check complete."
-
-echo "Creating server for minecraft ..."
 
 # The startup script moved out of --metadata and into --metadata-from-file.
 # --metadata takes comma separated key=value pairs, so a single comma anywhere
@@ -272,7 +281,14 @@ if ! docker inspect mc-server > /dev/null 2>&1; then
 fi
 EOS
 
-external_ip=$(gcloud compute instances create minecraft \
+# gcloud writes the created resource URL and any warnings to stderr. Capture it
+# so the run stays readable, and print it only if the creation actually failed.
+# Splitting the call from the jq parse also means a gcloud failure is caught
+# here rather than being masked by jq's exit status.
+create_log=$(mktemp)
+echo -n "  サーバーの作成 ... "
+
+if ! create_json=$(gcloud compute instances create minecraft \
   --format="json" \
   --project="$project_id" \
   --zone=us-west1-b \
@@ -287,16 +303,29 @@ external_ip=$(gcloud compute instances create minecraft \
   --reservation-affinity=any \
   --metadata=cos-update-strategy=update_enabled \
   --metadata-from-file=startup-script="$startup_script" \
-  | jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP')
+  2> "$create_log"); then
+  echo "失敗"
+  echo ""
+  echo "--------------------------------------------------------------------"
+  cat "$create_log"
+  echo "--------------------------------------------------------------------"
+  rm -f "$create_log"
+  exit 1
+fi
 
-echo "Creating server complete!"
+if [ "${MC_VERBOSE:-0}" == "1" ]; then
+  cat "$create_log"
+fi
+rm -f "$create_log"
+
+external_ip=$(echo "$create_json" | jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP')
+echo "完了"
 
 # The VM is up, but the container still has to be pulled and the world
 # generated. Probe UDP 19132 from here until the server actually answers,
 # so the script does not report success before you can join.
 echo ""
-echo "Waiting for the Minecraft server to start ..."
-echo -n "(マインクラフトサーバーの起動を待っています) "
+echo -n "マインクラフトの起動を待っています "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS
@@ -333,4 +362,3 @@ ${external_ip}
 
 EOS
 fi
-echo "==================== End create minecraft server  ===================="

--- a/create.sh
+++ b/create.sh
@@ -10,7 +10,7 @@ script_dir=$(dirname "${0}")
 echo "==================== Minecraft サーバーの作成 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認しています ... "
+echo -n "確認中 ... "
 project_id=$(gcloud config get project)
 # NOTE: `gcloud projects list --filter="$project_id"` is a bare-word filter that
 #       matches ANY field. A similarly named project makes it return multiple
@@ -149,7 +149,7 @@ EOS
 #       The output is captured rather than shown: it is a progress spinner and
 #       an operation id, neither of which is worth reading unless it fails.
 enable_log=$(mktemp)
-echo -n "  Google Cloud の準備 "
+echo -n "  Google Cloud の準備中 "
 for i in 1 2 3 4 5; do
   gcloud services enable compute.googleapis.com > "$enable_log" 2>&1 &
   enable_status=0
@@ -212,7 +212,7 @@ echo " 完了"
 fw_minecraft=$(gcloud compute firewall-rules list --format="json" | jq -r '.[] | select(.name=="minecraft")')
 
 if [ -z "$fw_minecraft" ]; then
-  run_step "ネットワークの設定" \
+  run_step "ネットワークの設定中" \
     gcloud compute --project="$project_id" \
     firewall-rules create minecraft \
     --description=minecraft \
@@ -287,7 +287,7 @@ EOS
 # here rather than being masked by jq's exit status.
 create_log=$(mktemp)
 create_out=$(mktemp)
-echo -n "  サーバーの作成 "
+echo -n "  サーバーの作成中 "
 
 gcloud compute instances create minecraft \
   --format="json" \
@@ -332,7 +332,7 @@ echo " 完了"
 # generated. Probe UDP 19132 from here until the server actually answers,
 # so the script does not report success before you can join.
 echo ""
-echo -n "マインクラフトの起動を待っています "
+echo -n "マインクラフト起動中 "
 
 ping_info=$(mktemp)
 

--- a/create.sh
+++ b/create.sh
@@ -38,6 +38,44 @@ echo -n "よろしいですか? [y/N]: "
 read -r gcp_info
 if [ "$gcp_info" != "y" ]; then exit 1 ; fi
 
+# EXISTING SERVER ==========
+# Checked before any of the questions below. Creating a second instance fails at
+# the very end otherwise, after every setting has been typed in, and the free
+# tier only covers one instance anyway.
+existing=$(gcloud compute instances describe minecraft --zone=us-west1-b \
+  --format="value(status,networkInterfaces[0].accessConfigs[0].natIP)" 2>/dev/null || true)
+
+if [ -n "$existing" ]; then
+  existing_status=$(echo "$existing" | cut -f1)
+  existing_ip=$(echo "$existing" | cut -f2)
+
+  case "$existing_status" in
+    RUNNING) existing_status="起動中" ;;
+    TERMINATED | STOPPED) existing_status="停止中" ;;
+  esac
+
+  cat <<EOS
+
+[ERROR] すでにマインクラフトサーバーが存在します。
+        (A Minecraft server already exists in this project.)
+
+ プロジェクト : $project_id
+ 状態         : $existing_status
+ IP アドレス  : ${existing_ip:-(停止中のため割り当てなし)}
+
+無料枠で動かせるサーバーは 1 台までのため、作成を中止しました。
+
+ 遊ぶ       : 上記の IP アドレスとポート 19132 で接続してください
+ 更新する   : メニューから update を選んでください
+ 作り直す   : メニューから delete を選んでから、もう一度 create してください
+
+作り直すとワールドのデータも消えます。残したい場合は、先にメニューから
+backup を実行してください。
+
+EOS
+  exit 1
+fi
+
 # SERVER NAME ==========
 cat <<EOS
 

--- a/create.sh
+++ b/create.sh
@@ -403,7 +403,15 @@ echo " 完了"
 # The VM is up, but the container still has to be pulled and the world
 # generated. Probe UDP 19132 from here until the server actually answers,
 # so the script does not report success before you can join.
-echo ""
+#
+# The notice comes before the wait rather than with the prompt itself: the wait
+# runs for minutes, and a screen that is not moving is easy to walk away from.
+cat <<EOS
+
+※ サーバー起動完了時、サーバー情報のファイルダウンロードが促されます。
+   こちらをダウンロードし、保管してください。
+
+EOS
 echo -n "マインクラフト起動中 "
 
 ping_info=$(mktemp)

--- a/create.sh
+++ b/create.sh
@@ -316,6 +316,12 @@ fi
 startup_script=$(mktemp)
 trap 'rm -f "$startup_script"' EXIT
 
+# VIEW_DISTANCE is set to 10 against a default of 32. Chunk data is the bulk of
+# what the server sends, so the default reaches much further than a 1GB RAM
+# shared-core instance can comfortably serve, in memory, CPU and outbound
+# traffic alike. Clients still render past this: client-side-chunk-generation is
+# on by default, so distant terrain is generated locally rather than sent.
+#
 # This runs on every boot, so it is written to be idempotent and to refresh
 # what it can. A reboot is the single update mechanism for the whole stack:
 #   - Container-Optimized OS applies whatever it staged onto its spare partition
@@ -343,7 +349,7 @@ if docker pull itzg/minecraft-bedrock-server:latest; then
 fi
 
 if ! docker inspect mc-server > /dev/null 2>&1; then
-  docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e ALLOW_LIST=false -e MAX_PLAYERS=${max_players:-2} -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
+  docker run -d -it --name mc-server --restart=always -e EULA=TRUE -e SERVER_NAME=${server_name:-ydak} -e GAMEMODE=${game_mode:-survival} -e DIFFICULTY=${difficulty:-normal} -e ALLOW_CHEATS=${allow_cheat:-false} -e ALLOW_LIST=false -e MAX_PLAYERS=${max_players:-2} -e VIEW_DISTANCE=10 -e DEFAULT_PLAYER_PERMISSION_LEVEL=${permission:-member} -e LEVEL_SEED=$seed -p 19132:19132/udp -v mc-volume:/data itzg/minecraft-bedrock-server:latest
 fi
 EOS
 
@@ -440,6 +446,7 @@ if wait_for_server "$external_ip" 900 "$ping_info"; then
  参加者の権限 : ${permission:-member}
  最大人数     : ${max_players:-2}
  シード値     : ${seed:-(ランダム)}
+ 描画距離     : 10 チャンク (既定の 32 から下げています)
 
 --------------------------------------------------------------------
  管理情報   ※ 自分用。共有する必要はありません

--- a/create.sh
+++ b/create.sh
@@ -149,17 +149,18 @@ EOS
 #       The output is captured rather than shown: it is a progress spinner and
 #       an operation id, neither of which is worth reading unless it fails.
 enable_log=$(mktemp)
-echo -n "  Google Cloud の準備 ... "
+echo -n "  Google Cloud の準備 "
 for i in 1 2 3 4 5; do
-  gcloud services enable compute.googleapis.com > "$enable_log" 2>&1
-  enable_status=$?
+  gcloud services enable compute.googleapis.com > "$enable_log" 2>&1 &
+  enable_status=0
+  wait_with_dots $! || enable_status=$?
   if [ "$enable_status" -eq 0 ]; then break; fi
 
   if [ "${MC_VERBOSE:-0}" == "1" ]; then cat "$enable_log"; fi
 
   if grep -qE 'billing-enabled|UREQ_PROJECT_BILLING_NOT_FOUND|Billing account for project' "$enable_log"; then
     rm -f "$enable_log"
-    echo "失敗"
+    echo " 失敗"
     cat <<EOS
 
 [ERROR] Billing is not enabled for this project.
@@ -178,15 +179,14 @@ EOS
     exit 1
   fi
 
-  echo -n "再試行しています ($i/5) "
-  sleep 70
+  sleep_with_dots 70
 done
 rm -f "$enable_log"
 
 if ! gcloud services list --enabled \
   --filter="config.name=compute.googleapis.com" \
   --format="value(config.name)" | grep -q .; then
-  echo "失敗"
+  echo " 失敗"
   cat <<EOS
 
 [ERROR] Google Cloud の準備に失敗しました。
@@ -204,9 +204,9 @@ for i in $(seq 1 20); do
     "$project_num-compute@developer.gserviceaccount.com" >/dev/null 2>&1; then
     break
   fi
-  sleep 15
+  sleep_with_dots 15
 done
-echo "完了"
+echo " 完了"
 
 # firewall =====================================================================
 fw_minecraft=$(gcloud compute firewall-rules list --format="json" | jq -r '.[] | select(.name=="minecraft")')
@@ -286,9 +286,10 @@ EOS
 # Splitting the call from the jq parse also means a gcloud failure is caught
 # here rather than being masked by jq's exit status.
 create_log=$(mktemp)
-echo -n "  サーバーの作成 ... "
+create_out=$(mktemp)
+echo -n "  サーバーの作成 "
 
-if ! create_json=$(gcloud compute instances create minecraft \
+gcloud compute instances create minecraft \
   --format="json" \
   --project="$project_id" \
   --zone=us-west1-b \
@@ -303,13 +304,18 @@ if ! create_json=$(gcloud compute instances create minecraft \
   --reservation-affinity=any \
   --metadata=cos-update-strategy=update_enabled \
   --metadata-from-file=startup-script="$startup_script" \
-  2> "$create_log"); then
-  echo "失敗"
+  > "$create_out" 2> "$create_log" &
+
+create_status=0
+wait_with_dots $! || create_status=$?
+
+if [ "$create_status" -ne 0 ]; then
+  echo " 失敗"
   echo ""
   echo "--------------------------------------------------------------------"
   cat "$create_log"
   echo "--------------------------------------------------------------------"
-  rm -f "$create_log"
+  rm -f "$create_log" "$create_out"
   exit 1
 fi
 
@@ -318,8 +324,9 @@ if [ "${MC_VERBOSE:-0}" == "1" ]; then
 fi
 rm -f "$create_log"
 
-external_ip=$(echo "$create_json" | jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP')
-echo "完了"
+external_ip=$(jq -r '.[].networkInterfaces[0].accessConfigs[0].natIP' < "$create_out")
+rm -f "$create_out"
+echo " 完了"
 
 # The VM is up, but the container still has to be pulled and the world
 # generated. Probe UDP 19132 from here until the server actually answers,

--- a/create.sh
+++ b/create.sh
@@ -10,14 +10,42 @@ script_dir=$(dirname "${0}")
 echo "==================== Minecraft サーバーの作成 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認中 ... "
-project_id=$(gcloud config get project 2> /dev/null)
+# Run in the background so the dots reflect real elapsed time rather than being
+# three characters printed up front.
+#
 # NOTE: `gcloud projects list --filter="$project_id"` is a bare-word filter that
 #       matches ANY field. A similarly named project makes it return multiple
-#       lines, which silently corrupts the service account name below.
-project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null 2>&1
-echo "完了"
+#       lines, which silently corrupts the service account name below, so
+#       describe is used instead.
+# Declared up front: they are assigned by sourcing the file the subshell
+# writes, which neither shellcheck nor set -e can see into.
+project_id=""
+project_num=""
+echo -n "確認中 "
+gcloud_info=$(mktemp)
+(
+  pid=$(gcloud config get project 2> /dev/null)
+  pnum=$(gcloud projects describe "$pid" --format="value(projectNumber)" 2> /dev/null)
+  gcloud config set project "$pid" > /dev/null 2>&1
+  printf 'project_id=%q\nproject_num=%q\n' "$pid" "$pnum"
+) > "$gcloud_info" 2> /dev/null &
+wait_with_dots $! || true
+# shellcheck disable=SC1090
+. "$gcloud_info"
+rm -f "$gcloud_info"
+if [ -z "$project_id" ]; then
+  echo " 失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud のプロジェクトを取得できませんでした。
+        下記で対象を指定してから、もう一度お試しください。
+
+  gcloud config set project <プロジェクト ID>
+
+EOS
+  exit 1
+fi
+echo " 完了"
 
 cat <<EOS
 

--- a/delete.sh
+++ b/delete.sh
@@ -10,7 +10,7 @@ script_dir=$(dirname "${0}")
 echo "==================== Minecraft サーバーの削除 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認しています ... "
+echo -n "確認中 ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
 gcloud config set project "$project_id" > /dev/null
@@ -37,9 +37,9 @@ read -r delete_yn
 if [ "$delete_yn" != "y" ]; then exit 1 ; fi
 
 echo ""
-run_step "サーバーの削除" \
+run_step "サーバーの削除中" \
   gcloud compute instances delete "$SERVER_NAME" --zone=us-west1-b --quiet
-run_step "ネットワーク設定の削除" \
+run_step "ネットワーク設定の削除中" \
   gcloud compute firewall-rules delete "$FIREWALL_RULE_NAME" --quiet
 
 echo ""

--- a/delete.sh
+++ b/delete.sh
@@ -11,9 +11,9 @@ echo "==================== Minecraft サーバーの削除 ===================="
 
 # GOOGLE CLOUD ==========
 echo -n "確認中 ... "
-project_id=$(gcloud config get project)
+project_id=$(gcloud config get project 2> /dev/null)
 project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
-gcloud config set project "$project_id" > /dev/null
+gcloud config set project "$project_id" > /dev/null 2>&1
 echo "完了"
 
 SERVER_NAME=minecraft

--- a/delete.sh
+++ b/delete.sh
@@ -10,11 +10,37 @@ script_dir=$(dirname "${0}")
 echo "==================== Minecraft サーバーの削除 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認中 ... "
-project_id=$(gcloud config get project 2> /dev/null)
-project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
-gcloud config set project "$project_id" > /dev/null 2>&1
-echo "完了"
+# Run in the background so the dots reflect real elapsed time rather than being
+# three characters printed up front.
+# Declared up front: they are assigned by sourcing the file the subshell
+# writes, which neither shellcheck nor set -e can see into.
+project_id=""
+project_num=""
+echo -n "確認中 "
+gcloud_info=$(mktemp)
+(
+  pid=$(gcloud config get project 2> /dev/null)
+  pnum=$(gcloud projects describe "$pid" --format="value(projectNumber)" 2> /dev/null)
+  gcloud config set project "$pid" > /dev/null 2>&1
+  printf 'project_id=%q\nproject_num=%q\n' "$pid" "$pnum"
+) > "$gcloud_info" 2> /dev/null &
+wait_with_dots $! || true
+# shellcheck disable=SC1090
+. "$gcloud_info"
+rm -f "$gcloud_info"
+if [ -z "$project_id" ]; then
+  echo " 失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud のプロジェクトを取得できませんでした。
+        下記で対象を指定してから、もう一度お試しください。
+
+  gcloud config set project <プロジェクト ID>
+
+EOS
+  exit 1
+fi
+echo " 完了"
 
 SERVER_NAME=minecraft
 FIREWALL_RULE_NAME=minecraft

--- a/delete.sh
+++ b/delete.sh
@@ -7,13 +7,14 @@ script_dir=$(dirname "${0}")
 # shellcheck source=const.sh
 . "$script_dir/const.sh"
 
-echo "==================== Start delete minecraft server  ===================="
+echo "==================== Minecraft サーバーの削除 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "Setting Google Cloud info ..."
+echo -n "確認しています ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects list --filter="$project_id" --format="value(PROJECT_NUMBER)")
-gcloud config set project "$project_id"
+gcloud config set project "$project_id" > /dev/null
+echo "完了"
 
 SERVER_NAME=minecraft
 FIREWALL_RULE_NAME=minecraft
@@ -35,11 +36,12 @@ echo -n "よろしいですか? [y/N]: "
 read -r delete_yn
 if [ "$delete_yn" != "y" ]; then exit 1 ; fi
 
-echo "Deleting minecraft server ..."
+echo ""
+run_step "サーバーの削除" \
+  gcloud compute instances delete "$SERVER_NAME" --zone=us-west1-b --quiet
+run_step "ネットワーク設定の削除" \
+  gcloud compute firewall-rules delete "$FIREWALL_RULE_NAME" --quiet
 
-gcloud compute instances delete $SERVER_NAME --zone=us-west1-b --quiet
-gcloud compute firewall-rules delete $FIREWALL_RULE_NAME --quiet
+echo ""
+echo "削除が完了しました。"
 
-echo "Delete complete!"
-
-echo "==================== End delete minecraft server  ===================="

--- a/functions.sh
+++ b/functions.sh
@@ -10,6 +10,10 @@ function wait_with_dots() {
   local pid=$1
   local status=0
 
+  # Start at three so the label never sits on its own for a moment, then add one
+  # a second from there.
+  echo -n "..."
+
   while kill -0 "$pid" 2> /dev/null; do
     echo -n "."
     sleep 1
@@ -178,6 +182,10 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 # land on a dot a second, rather than drifting out to two.
 sock.settimeout(0.8)
 next_tick = time.time()
+
+# Same three-dot head start as wait_with_dots, so both read the same way.
+sys.stdout.write("...")
+sys.stdout.flush()
 
 while time.time() < deadline:
     # ID_UNCONNECTED_PING: id(1) + time(8) + magic(16) + client guid(8)

--- a/functions.sh
+++ b/functions.sh
@@ -97,12 +97,14 @@ function positive_num_validation() {
 # Arguments:
 #   1: External IP address of the server
 #   2: Timeout in seconds
+#   3: Optional path to write the answered details to, as shell assignments
 # Returns:
 #   0 if the server answered, 1 on timeout
 ################################################################################
 function wait_for_server() {
   local ip=$1
   local timeout=$2
+  local info_path=${3:-}
 
   if ! command -v python3 > /dev/null; then
     echo ""
@@ -111,7 +113,8 @@ function wait_for_server() {
     return 0
   fi
 
-  python3 - "$ip" "$timeout" <<'PYEOF'
+  python3 - "$ip" "$timeout" "$info_path" <<'PYEOF'
+import shlex
 import socket
 import struct
 import sys
@@ -123,6 +126,7 @@ PORT = 19132
 
 ip = sys.argv[1]
 deadline = time.time() + int(sys.argv[2])
+info_path = sys.argv[3] if len(sys.argv) > 3 else ""
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.settimeout(1.0)
@@ -145,6 +149,17 @@ while time.time() < deadline:
             print("  Server name : %s" % fields[1])
             print("  Version     : %s" % fields[3])
             print("  Players     : %s/%s" % (fields[4], fields[5]))
+            # The MOTD is whatever the operator typed, so quote every value
+            # before it is sourced back into the shell.
+            if info_path:
+                lines = [
+                    "MC_NAME=" + shlex.quote(fields[1]),
+                    "MC_VERSION=" + shlex.quote(fields[3]),
+                    "MC_MAX_PLAYERS=" + shlex.quote(fields[5]),
+                    "",
+                ]
+                with open(info_path, "w", encoding="utf-8") as fh:
+                    fh.write(chr(10).join(lines))
         sys.exit(0)
 
     sys.stdout.write(".")

--- a/functions.sh
+++ b/functions.sh
@@ -1,4 +1,44 @@
 ################################################################################
+# Prints a dot a second until the given process exits.
+#
+# Arguments:
+#   1: Process id to wait for
+# Returns:
+#   The exit status of that process
+################################################################################
+function wait_with_dots() {
+  local pid=$1
+  local status=0
+
+  while kill -0 "$pid" 2> /dev/null; do
+    echo -n "."
+    sleep 1
+  done
+
+  # The process has already gone, but bash keeps its status until it is reaped.
+  wait "$pid" || status=$?
+  return $status
+}
+
+################################################################################
+# Prints a dot a second for the given number of seconds.
+#
+# Arguments:
+#   1: Seconds to wait
+# Returns:
+#   None
+################################################################################
+function sleep_with_dots() {
+  local seconds=$1
+  local i
+
+  for ((i = 0; i < seconds; i++)); do
+    echo -n "."
+    sleep 1
+  done
+}
+
+################################################################################
 # Runs a command, showing a short label instead of its output.
 #
 # gcloud prints tables, resource URLs and progress spinners that mean nothing to
@@ -24,18 +64,23 @@ function run_step() {
     return $?
   fi
 
-  local log
+  local log status
   log=$(mktemp)
-  echo -n "  $label ... "
+  echo -n "  $label "
 
-  if "$@" > "$log" 2>&1; then
-    echo "完了"
+  # Run in the background so a dot can be printed every second. Some of these
+  # calls take minutes, and a screen that has not moved reads as a hang.
+  "$@" > "$log" 2>&1 &
+  status=0
+  wait_with_dots $! || status=$?
+
+  if [ "$status" -eq 0 ]; then
+    echo " 完了"
     rm -f "$log"
     return 0
   fi
 
-  local status=$?
-  echo "失敗"
+  echo " 失敗"
   echo ""
   echo "[ERROR] 処理に失敗しました。(The step above failed.)"
   echo "--------------------------------------------------------------------"
@@ -129,7 +174,10 @@ deadline = time.time() + int(sys.argv[2])
 info_path = sys.argv[3] if len(sys.argv) > 3 else ""
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.settimeout(1.0)
+# Kept under the one second tick so that the probe and the wait together still
+# land on a dot a second, rather than drifting out to two.
+sock.settimeout(0.8)
+next_tick = time.time()
 
 while time.time() < deadline:
     # ID_UNCONNECTED_PING: id(1) + time(8) + magic(16) + client guid(8)
@@ -164,7 +212,10 @@ while time.time() < deadline:
 
     sys.stdout.write(".")
     sys.stdout.flush()
-    time.sleep(1)
+    next_tick += 1.0
+    remaining = next_tick - time.time()
+    if remaining > 0:
+        time.sleep(remaining)
 
 print("")
 sys.exit(1)

--- a/functions.sh
+++ b/functions.sh
@@ -1,4 +1,51 @@
 ################################################################################
+# Runs a command, showing a short label instead of its output.
+#
+# gcloud prints tables, resource URLs and progress spinners that mean nothing to
+# someone who just wants a Minecraft server, and a wall of them reads as
+# something having gone wrong. The output is captured and only printed when the
+# command fails, which is the point at which it becomes worth reading.
+#
+# Set MC_VERBOSE=1 to pass everything straight through instead.
+#
+# Arguments:
+#   1: Label shown to the user
+#   2+: Command to run
+# Returns:
+#   The exit status of the command
+################################################################################
+function run_step() {
+  local label=$1
+  shift
+
+  if [ "${MC_VERBOSE:-0}" == "1" ]; then
+    echo "  $label ..."
+    "$@"
+    return $?
+  fi
+
+  local log
+  log=$(mktemp)
+  echo -n "  $label ... "
+
+  if "$@" > "$log" 2>&1; then
+    echo "完了"
+    rm -f "$log"
+    return 0
+  fi
+
+  local status=$?
+  echo "失敗"
+  echo ""
+  echo "[ERROR] 処理に失敗しました。(The step above failed.)"
+  echo "--------------------------------------------------------------------"
+  cat "$log"
+  echo "--------------------------------------------------------------------"
+  rm -f "$log"
+  return $status
+}
+
+################################################################################
 # Receives a string and check if it is a specified number.
 # If it is not a valid number, exits with error code 1.
 #

--- a/mc.sh
+++ b/mc.sh
@@ -94,9 +94,9 @@ trap 'rm -rf "$work_dir"' EXIT
 # Minecraft server, so they are kept out of the way unless a specific ref was
 # asked for, in which case showing it is how that choice gets confirmed.
 if [ "$REF" == "main" ]; then
-  echo -n "準備しています ... "
+  echo -n "準備中 ... "
 else
-  echo -n "準備しています (${REF}) ... "
+  echo -n "準備中 (${REF}) ... "
 fi
 
 # pipefail is scoped to this subshell so that a failed download is caught here

--- a/mc.sh
+++ b/mc.sh
@@ -85,22 +85,36 @@ if [ -c /dev/tty ] && (: < /dev/tty) 2> /dev/null; then
   tty_available=1
 fi
 
-echo "==================== gcp-minecraft ===================="
+echo "==================== Minecraft サーバー管理 ===================="
 
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 
-echo "Downloading ${REPO} (${REF}) ..."
+# The repository name and branch mean nothing to someone who just wants a
+# Minecraft server, so they are kept out of the way unless a specific ref was
+# asked for, in which case showing it is how that choice gets confirmed.
+if [ "$REF" == "main" ]; then
+  echo -n "準備しています ... "
+else
+  echo -n "準備しています (${REF}) ... "
+fi
 
 # pipefail is scoped to this subshell so that a failed download is caught here
 # rather than being masked by tar's exit status.
 if ! (set -o pipefail
       curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/${REF}" \
-        | tar xz -C "$work_dir" --strip-components=1); then
-  echo "[ERROR] Failed to download ${REPO} (${REF})."
-  echo "        (ダウンロードに失敗しました。REF の指定を確認して下さい。)"
+        | tar xz -C "$work_dir" --strip-components=1) > /dev/null 2>&1; then
+  echo "失敗"
+  cat <<EOS
+
+[ERROR] 必要なファイルを取得できませんでした。
+        通信環境を確認して、もう一度お試しください。
+        (Failed to download ${REPO} (${REF}).)
+
+EOS
   exit 1
 fi
+echo "完了"
 
 # shellcheck source=functions.sh
 . "${work_dir}/functions.sh"

--- a/mc.sh
+++ b/mc.sh
@@ -106,6 +106,7 @@ fi
  curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/${REF}" \
    | tar xz -C "$work_dir" --strip-components=1) > /dev/null 2>&1 &
 download_pid=$!
+echo -n "..."
 while kill -0 "$download_pid" 2> /dev/null; do
   echo -n "."
   sleep 1

--- a/mc.sh
+++ b/mc.sh
@@ -94,17 +94,27 @@ trap 'rm -rf "$work_dir"' EXIT
 # Minecraft server, so they are kept out of the way unless a specific ref was
 # asked for, in which case showing it is how that choice gets confirmed.
 if [ "$REF" == "main" ]; then
-  echo -n "準備中 ... "
+  echo -n "準備中 "
 else
-  echo -n "準備中 (${REF}) ... "
+  echo -n "準備中 (${REF}) "
 fi
 
 # pipefail is scoped to this subshell so that a failed download is caught here
-# rather than being masked by tar's exit status.
-if ! (set -o pipefail
-      curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/${REF}" \
-        | tar xz -C "$work_dir" --strip-components=1) > /dev/null 2>&1; then
-  echo "失敗"
+# rather than being masked by tar's exit status. functions.sh is not available
+# yet, so the dot loop is written out rather than calling wait_with_dots.
+(set -o pipefail
+ curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/${REF}" \
+   | tar xz -C "$work_dir" --strip-components=1) > /dev/null 2>&1 &
+download_pid=$!
+while kill -0 "$download_pid" 2> /dev/null; do
+  echo -n "."
+  sleep 1
+done
+download_status=0
+wait "$download_pid" || download_status=$?
+
+if [ "$download_status" -ne 0 ]; then
+  echo " 失敗"
   cat <<EOS
 
 [ERROR] 必要なファイルを取得できませんでした。
@@ -114,7 +124,7 @@ if ! (set -o pipefail
 EOS
   exit 1
 fi
-echo "完了"
+echo " 完了"
 
 # shellcheck source=functions.sh
 . "${work_dir}/functions.sh"

--- a/restore.sh
+++ b/restore.sh
@@ -12,7 +12,7 @@ BACKUP_DIR="$HOME"
 echo "==================== ワールドの復元 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認しています ... "
+echo -n "確認中 ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
 gcloud config set project "$project_id" > /dev/null
@@ -101,7 +101,7 @@ fi
 backup_file="${backups[$backup_num - 1]}"
 
 # Check the archive here rather than after the world has been replaced.
-echo -n "  データの検証 ... "
+echo -n "  データの検証中 ... "
 if ! tar tzf "$backup_file" > /dev/null 2>&1; then
   echo "失敗"
   echo "[ERROR] $(basename "$backup_file") は壊れています。"
@@ -130,10 +130,10 @@ read -r restore_yn
 if [ "$restore_yn" != "y" ]; then exit 1 ; fi
 
 echo ""
-run_step "サーバーの停止" \
+run_step "サーバーの停止中" \
   gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo -n "  ワールドの書き戻し ... "
+echo -n "  ワールドの書き戻し中 ... "
 
 # The archive is expanded into a scratch directory first and the current world
 # is only moved aside once that has succeeded. A truncated upload therefore
@@ -168,11 +168,11 @@ EOS
 fi
 
 echo "完了"
-run_step "サーバーの再開" \
+run_step "サーバーの再開中" \
   gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 echo ""
-echo -n "マインクラフトの再開を待っています "
+echo -n "マインクラフト再開中 "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS

--- a/restore.sh
+++ b/restore.sh
@@ -13,9 +13,9 @@ echo "==================== ワールドの復元 ===================="
 
 # GOOGLE CLOUD ==========
 echo -n "確認中 ... "
-project_id=$(gcloud config get project)
+project_id=$(gcloud config get project 2> /dev/null)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null
+gcloud config set project "$project_id" > /dev/null 2>&1
 echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
@@ -131,9 +131,9 @@ if [ "$restore_yn" != "y" ]; then exit 1 ; fi
 
 echo ""
 run_step "サーバーの停止中" \
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo -n "  ワールドの書き戻し中 ... "
+echo -n "  ワールドの書き戻し中 "
 
 # The archive is expanded into a scratch directory first and the current world
 # is only moved aside once that has succeeded. A truncated upload therefore
@@ -151,8 +151,14 @@ mv /data/.restore/worlds /data/worlds
 rm -rf /data/.restore
 "'
 
-if ! gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="$restore_cmd" \
-  < "$backup_file" > /dev/null 2>&1; then
+gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="$restore_cmd" \
+  < "$backup_file" > /dev/null 2>&1 &
+
+restore_status=0
+wait_with_dots $! || restore_status=$?
+
+if [ "$restore_status" -ne 0 ]; then
+  echo " 失敗"
   cat <<EOS
 
 [ERROR] Failed to restore the world. (ワールドの復元に失敗しました。)
@@ -163,13 +169,13 @@ archive has been expanded successfully.
  変更されていません。)
 
 EOS
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null || true
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null 2>&1 || true
   exit 1
 fi
 
-echo "完了"
+echo " 完了"
 run_step "サーバーの再開中" \
-  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
+  gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 echo ""
 echo -n "マインクラフト再開中 "
@@ -196,7 +202,7 @@ else
 Check the log with the following command.
 (下記でログを確認して下さい。)
 
-  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+  gcloud compute ssh --quiet $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
 
 EOS
   exit 1

--- a/restore.sh
+++ b/restore.sh
@@ -9,13 +9,14 @@ ZONE=us-west1-b
 SERVER_NAME=minecraft
 BACKUP_DIR="$HOME"
 
-echo "==================== Start minecraft restore ===================="
+echo "==================== ワールドの復元 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "Setting Google Cloud info ..."
+echo -n "確認しています ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id"
+gcloud config set project "$project_id" > /dev/null
+echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -100,10 +101,10 @@ fi
 backup_file="${backups[$backup_num - 1]}"
 
 # Check the archive here rather than after the world has been replaced.
-echo "Verifying the archive ..."
+echo -n "  データの検証 ... "
 if ! tar tzf "$backup_file" > /dev/null 2>&1; then
-  echo "[ERROR] $(basename "$backup_file") is corrupted."
-  echo "        ($(basename "$backup_file") は壊れています。)"
+  echo "失敗"
+  echo "[ERROR] $(basename "$backup_file") は壊れています。"
   exit 1
 fi
 
@@ -128,10 +129,11 @@ echo -n "よろしいですか? [y/N]: "
 read -r restore_yn
 if [ "$restore_yn" != "y" ]; then exit 1 ; fi
 
-echo "Stopping the server ..."
-gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server" > /dev/null
+echo ""
+run_step "サーバーの停止" \
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker stop -t 60 mc-server"
 
-echo "Uploading the world ..."
+echo -n "  ワールドの書き戻し ... "
 
 # The archive is expanded into a scratch directory first and the current world
 # is only moved aside once that has succeeded. A truncated upload therefore
@@ -165,18 +167,17 @@ EOS
   exit 1
 fi
 
-echo "Restarting the server ..."
-gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server" > /dev/null
+echo "完了"
+run_step "サーバーの再開" \
+  gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" --command="docker start mc-server"
 
 echo ""
-echo "Waiting for the Minecraft server to come back ..."
-echo -n "(マインクラフトサーバーの再起動を待っています) "
+echo -n "マインクラフトの再開を待っています "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS
 
-Restore complete!
- (復元が完了しました！)
+復元が完了しました！
 
 ################################################################################
 ${external_ip}
@@ -201,4 +202,3 @@ EOS
   exit 1
 fi
 
-echo "==================== End minecraft restore ===================="

--- a/restore.sh
+++ b/restore.sh
@@ -12,11 +12,37 @@ BACKUP_DIR="$HOME"
 echo "==================== ワールドの復元 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認中 ... "
-project_id=$(gcloud config get project 2> /dev/null)
-project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null 2>&1
-echo "完了"
+# Run in the background so the dots reflect real elapsed time rather than
+# being three characters printed up front.
+# Declared up front: they are assigned by sourcing the file the subshell
+# writes, which neither shellcheck nor set -e can see into.
+project_id=""
+project_num=""
+echo -n "確認中 "
+gcloud_info=$(mktemp)
+(
+  pid=$(gcloud config get project 2> /dev/null)
+  pnum=$(gcloud projects describe "$pid" --format="value(projectNumber)" 2> /dev/null)
+  gcloud config set project "$pid" > /dev/null 2>&1
+  printf 'project_id=%q\nproject_num=%q\n' "$pid" "$pnum"
+) > "$gcloud_info" 2> /dev/null &
+wait_with_dots $! || true
+# shellcheck disable=SC1090
+. "$gcloud_info"
+rm -f "$gcloud_info"
+if [ -z "$project_id" ]; then
+  echo " 失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud のプロジェクトを取得できませんでした。
+        下記で対象を指定してから、もう一度お試しください。
+
+  gcloud config set project <プロジェクト ID>
+
+EOS
+  exit 1
+fi
+echo " 完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -101,9 +127,13 @@ fi
 backup_file="${backups[$backup_num - 1]}"
 
 # Check the archive here rather than after the world has been replaced.
-echo -n "  データの検証中 ... "
-if ! tar tzf "$backup_file" > /dev/null 2>&1; then
-  echo "失敗"
+echo -n "  データの検証中 "
+tar tzf "$backup_file" > /dev/null 2>&1 &
+verify_status=0
+wait_with_dots $! || verify_status=$?
+
+if [ "$verify_status" -ne 0 ]; then
+  echo " 失敗"
   echo "[ERROR] $(basename "$backup_file") は壊れています。"
   exit 1
 fi

--- a/update.sh
+++ b/update.sh
@@ -11,7 +11,7 @@ SERVER_NAME=minecraft
 echo "==================== Minecraft の更新 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認しています ... "
+echo -n "確認中 ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
 gcloud config set project "$project_id" > /dev/null
@@ -81,7 +81,7 @@ else
   echo "OS の更新はありません。"
 fi
 
-echo -n "  更新しています ... "
+echo -n "  更新中 ... "
 
 # The image turns SIGTERM into a clean `stop`, but the shutdown sequence is
 # less forgiving than `docker stop`, so stop the container explicitly first.
@@ -92,7 +92,7 @@ gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
 
 echo "完了"
 echo ""
-echo -n "マインクラフトの再起動を待っています "
+echo -n "マインクラフト再起動中 "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS

--- a/update.sh
+++ b/update.sh
@@ -8,13 +8,14 @@ script_dir=$(dirname "${0}")
 ZONE=us-west1-b
 SERVER_NAME=minecraft
 
-echo "==================== Start minecraft update ===================="
+echo "==================== Minecraft の更新 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "Setting Google Cloud info ..."
+echo -n "確認しています ... "
 project_id=$(gcloud config get project)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id"
+gcloud config set project "$project_id" > /dev/null
+echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -71,19 +72,16 @@ if [ "$update_yn" != "y" ]; then exit 1 ; fi
 # Note that the first two only apply to instances created by a create.sh that
 # writes this startup script. On older instances the reboot still refreshes
 # Bedrock, and nothing breaks.
-echo "Checking for OS updates ..."
 os_status=$(gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
   --command="sudo update_engine_client --status 2>/dev/null | grep CURRENT_OP" 2>/dev/null || true)
 
 if echo "$os_status" | grep -q "UPDATED_NEED_REBOOT"; then
-  echo "  An OS update is staged and will be applied by this reboot."
-  echo "  (OS の更新が準備済みです。この再起動で適用されます。)"
+  echo "OS の更新が見つかりました。あわせて適用します。"
 else
-  echo "  No OS update is staged."
-  echo "  (準備済みの OS 更新はありません。)"
+  echo "OS の更新はありません。"
 fi
 
-echo "Rebooting to update ..."
+echo -n "  更新しています ... "
 
 # The image turns SIGTERM into a clean `stop`, but the shutdown sequence is
 # less forgiving than `docker stop`, so stop the container explicitly first.
@@ -92,15 +90,14 @@ echo "Rebooting to update ..."
 gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
   --command="docker stop -t 60 mc-server && sudo reboot" > /dev/null 2>&1 || true
 
+echo "完了"
 echo ""
-echo "Waiting for the Minecraft server to come back ..."
-echo -n "(マインクラフトサーバーの再起動を待っています) "
+echo -n "マインクラフトの再起動を待っています "
 
 if wait_for_server "$external_ip" 900; then
   cat <<EOS
 
-Minecraft has been updated!
- (マインクラフトの更新が完了しました！)
+更新が完了しました！
 
 ################################################################################
 ${external_ip}
@@ -110,12 +107,10 @@ EOS
 else
   cat <<EOS
 
-[WARN] The server did not answer within 15 minutes.
-       (15分以内にサーバーが応答しませんでした。)
+[WARN] 15 分待ちましたが、サーバーが応答しませんでした。
 
-The container may still be downloading the new version.
-Check the log with the following command.
-(新しいバージョンを取得中の可能性があります。下記でログを確認して下さい。)
+新しいバージョンを取得している途中かもしれません。
+下記でログを確認できます。
 
   gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
 
@@ -123,4 +118,3 @@ EOS
   exit 1
 fi
 
-echo "==================== End minecraft update ===================="

--- a/update.sh
+++ b/update.sh
@@ -11,11 +11,37 @@ SERVER_NAME=minecraft
 echo "==================== Minecraft の更新 ===================="
 
 # GOOGLE CLOUD ==========
-echo -n "確認中 ... "
-project_id=$(gcloud config get project 2> /dev/null)
-project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null 2>&1
-echo "完了"
+# Run in the background so the dots reflect real elapsed time rather than
+# being three characters printed up front.
+# Declared up front: they are assigned by sourcing the file the subshell
+# writes, which neither shellcheck nor set -e can see into.
+project_id=""
+project_num=""
+echo -n "確認中 "
+gcloud_info=$(mktemp)
+(
+  pid=$(gcloud config get project 2> /dev/null)
+  pnum=$(gcloud projects describe "$pid" --format="value(projectNumber)" 2> /dev/null)
+  gcloud config set project "$pid" > /dev/null 2>&1
+  printf 'project_id=%q\nproject_num=%q\n' "$pid" "$pnum"
+) > "$gcloud_info" 2> /dev/null &
+wait_with_dots $! || true
+# shellcheck disable=SC1090
+. "$gcloud_info"
+rm -f "$gcloud_info"
+if [ -z "$project_id" ]; then
+  echo " 失敗"
+  cat <<EOS
+
+[ERROR] Google Cloud のプロジェクトを取得できませんでした。
+        下記で対象を指定してから、もう一度お試しください。
+
+  gcloud config set project <プロジェクト ID>
+
+EOS
+  exit 1
+fi
+echo " 完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
 external_ip=$(gcloud compute instances describe "$SERVER_NAME" --zone="$ZONE" \
@@ -90,16 +116,17 @@ else
   echo "OS の更新はありません。"
 fi
 
-echo -n "  更新中 ... "
+echo -n "  更新中 "
 
 # The image turns SIGTERM into a clean `stop`, but the shutdown sequence is
 # less forgiving than `docker stop`, so stop the container explicitly first.
 # The connection drops as the instance goes down, so ssh reports failure here;
 # wait_for_server below is what actually confirms the outcome.
 gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" \
-  --command="docker stop -t 60 mc-server && sudo reboot" > /dev/null 2>&1 || true
+  --command="docker stop -t 60 mc-server && sudo reboot" > /dev/null 2>&1 &
+wait_with_dots $! || true
 
-echo "完了"
+echo " 完了"
 echo ""
 echo -n "マインクラフト再起動中 "
 

--- a/update.sh
+++ b/update.sh
@@ -12,9 +12,9 @@ echo "==================== Minecraft の更新 ===================="
 
 # GOOGLE CLOUD ==========
 echo -n "確認中 ... "
-project_id=$(gcloud config get project)
+project_id=$(gcloud config get project 2> /dev/null)
 project_num=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
-gcloud config set project "$project_id" > /dev/null
+gcloud config set project "$project_id" > /dev/null 2>&1
 echo "完了"
 
 # A stopped instance has no external IP, so an empty value is also a failure.
@@ -72,8 +72,17 @@ if [ "$update_yn" != "y" ]; then exit 1 ; fi
 # Note that the first two only apply to instances created by a create.sh that
 # writes this startup script. On older instances the reboot still refreshes
 # Bedrock, and nothing breaks.
-os_status=$(gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
-  --command="sudo update_engine_client --status 2>/dev/null | grep CURRENT_OP" 2>/dev/null || true)
+# The first `gcloud compute ssh` in a fresh CloudShell generates an SSH key,
+# which takes long enough to look like a hang with no output at all.
+echo -n "  サーバーへ接続中 "
+os_out=$(mktemp)
+gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" \
+  --command="sudo update_engine_client --status 2>/dev/null | grep CURRENT_OP" \
+  > "$os_out" 2>/dev/null &
+wait_with_dots $! || true
+os_status=$(cat "$os_out" 2>/dev/null || true)
+rm -f "$os_out"
+echo " 完了"
 
 if echo "$os_status" | grep -q "UPDATED_NEED_REBOOT"; then
   echo "OS の更新が見つかりました。あわせて適用します。"
@@ -87,7 +96,7 @@ echo -n "  更新中 ... "
 # less forgiving than `docker stop`, so stop the container explicitly first.
 # The connection drops as the instance goes down, so ssh reports failure here;
 # wait_for_server below is what actually confirms the outcome.
-gcloud compute ssh --zone "$ZONE" "$SERVER_NAME" \
+gcloud compute ssh --quiet --zone "$ZONE" "$SERVER_NAME" \
   --command="docker stop -t 60 mc-server && sudo reboot" > /dev/null 2>&1 || true
 
 echo "完了"
@@ -112,7 +121,7 @@ else
 新しいバージョンを取得している途中かもしれません。
 下記でログを確認できます。
 
-  gcloud compute ssh $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
+  gcloud compute ssh --quiet $SERVER_NAME --zone=$ZONE --command='docker logs mc-server | tail -30'
 
 EOS
   exit 1


### PR DESCRIPTION
## 背景

gcloud の生の出力が画面を埋めており、内部事情がそのまま見えていた。

```
Downloading ydak/gcp-minecraft (main) ...
Enabling compute.googleapis.com ...
Operation "operations/acf.p2-718912790457-3cba6c83-..." finished successfully.
Checking Firewall ...
Creating firewall...working..Created [https://www.googleapis.com/compute/v1/...].
NAME: minecraft
NETWORK: default
DIRECTION: INGRESS
Checking latest COS image ...
Created [https://www.googleapis.com/compute/v1/projects/.../instances/minecraft].
```

**サーバーを立てたいだけの人にとっては読む意味が無い**うえ、量が多いぶん
何か問題が起きているようにも見える。

## 変更内容

**成功時は短い日本語の進捗のみ、失敗したときに初めて全文を表示する。**

### 変更後

```
==================== Minecraft サーバー管理 ====================
準備しています ... 完了

-*-*-*-*- [ACTION (操作を選択)] -*-*-*-*-
...

==================== Minecraft サーバーの作成 ====================
確認しています ... 完了

（各種の質問）

設定が完了しました。サーバーを作成します。数分かかります。

  Google Cloud の準備 ... 完了
  ネットワークの設定 ... 完了
  サーバーの作成 ... 完了

マインクラフトの起動を待っています ............
  Server name : ydak
  Version     : 1.26.40
  Players     : 0/2
```

### 失敗したときだけ全文を出す

```
  サーバーの作成 ... 失敗

--------------------------------------------------------------------
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Quota exceeded for quota metric ...
--------------------------------------------------------------------
```

### `functions.sh`

`run_step()` を追加した。ラベルを表示してコマンドを実行し、出力を捕捉する。

- 成功時は「完了」だけを表示し、出力は捨てる
- 失敗時は「失敗」に続けて捕捉した全文を表示する
- **`MC_VERBOSE=1` を指定すると従来どおり素通しする**（調査用の逃げ道）

### `mc.sh`

リポジトリ名とブランチを表示しないようにした。ただし **`REF` を指定した場合のみ
括弧内に出す** — バージョンを固定したことの確認手段として必要なため。

```
準備しています ... 完了            ← 通常
準備しています (v2.0.0) ... 完了    ← REF 指定時
```

### 各スクリプト

- バナーと進捗表示を日本語に統一
- `gcloud config set project` の `Updated property` を抑制
- API 有効化・ファイアウォール作成・インスタンス作成・停止・再開・削除を
  `run_step` または同等の捕捉方式に変更

エラー時の案内は日本語を主にし、**原文のメッセージは括弧内に残した。**
利用者が検索する際に必要になるため。

## 副次的に直った不具合

`instances create` の出力を `jq` に渡す前に切り離した。

```diff
-external_ip=$(gcloud compute instances create ... | jq -r '...')
+if ! create_json=$(gcloud compute instances create ... 2> "$create_log"); then
+  ...失敗時の処理...
+fi
+external_ip=$(echo "$create_json" | jq -r '...')
```

従来はパイプの終了ステータスが `jq` のものになるため、**gcloud が失敗しても
検出できなかった。** 分離したことで失敗が捕捉できるようになった。

## 動作確認

`run_step` をモックコマンドで検証した。

| 状況 | 結果 |
| --- | --- |
| 成功 | `サーバーの作成 ... 完了`（出力は非表示） |
| 失敗 | `失敗` + 捕捉した全文を表示、戻り値 1 を返す |
| `MC_VERBOSE=1` | 出力をそのまま素通し |

- `shellcheck -x` / `bash -n` 指摘なし
- 全 8 ファイルの改行コードが LF であることを確認

**未確認:** 実機での通し実行。表示の変更が中心だが、`instances create` の
呼び出し構造を変えているため、`create` は一度実行して確認することを勧める。

---

## 追記: サーバー情報をファイルで渡す

作成完了時に IP を画面に出すだけだったため、**接続情報を控えるのは利用者任せ**で、
CloudShell を閉じると失われていた。

接続情報と管理情報をまとめたテキストを `$HOME` に書き出し、
`cloudshell download` でブラウザに渡すようにした。バックアップ機能と同じ流れになる。

```
====================================================================
 Minecraft サーバー情報
====================================================================
 作成日時 : 2026-08-09 05:19:20 JST

--------------------------------------------------------------------
 接続情報   ※ 一緒に遊ぶ人に伝える内容
--------------------------------------------------------------------
 サーバーアドレス : 34.177.114.93
 ポート           : 19132
 サーバー名       : ydak
 エディション     : 統合版 (Bedrock)
 バージョン       : 1.26.40

--------------------------------------------------------------------
 ゲーム設定
--------------------------------------------------------------------
 ゲームモード : survival
 難易度       : normal
 チート       : false
 参加者の権限 : member
 最大人数     : 2
 シード値     : (ランダム)

--------------------------------------------------------------------
 管理情報   ※ 自分用。共有する必要はありません
--------------------------------------------------------------------
 プロジェクト ID  : minecraft-ydak-project-id
 プロジェクト番号 : 718912790457
 インスタンス名   : minecraft
 ゾーン           : us-west1-b
 マシンタイプ     : e2-micro

--------------------------------------------------------------------
 操作方法
--------------------------------------------------------------------
 CloudShell で下記を実行し、メニューから選びます。

   curl -fsSL https://daylifehack.com/mc | bash

   create  : サーバーを作成する
   update  : マインクラフトとホストを更新する
   backup  : ワールドをバックアップする
   restore : ワールドを復元する
   delete  : サーバーを削除する (ワールドも消えます)

--------------------------------------------------------------------
 注意
--------------------------------------------------------------------
 ・許可リストは無効です。この IP を知っていれば誰でも参加できます。
 ・サーバーを停止・起動すると IP アドレスが変わります。
   再起動 (reboot) では変わりません。
 ・無料枠で動かせるサーバーは 1 台までです。
 ・下り通信は 1GB/月 まで無料です。超過分は約 $0.12/GB です。
   目安として 1 人が 1 時間遊ぶとおよそ 36MB です。
====================================================================
```

**「一緒に遊ぶ人に伝える内容」と「自分用」を分けている。** 前者だけを転送すれば済む。

### バージョンの取得元

入力値ではなく**サーバーの応答**から取っている。クライアントが実際に必要とする値であるため。

これに伴い `wait_for_server` に第 3 引数を追加した。指定すると、応答から得た
サーバー名・バージョン・最大人数をシェル変数の形式で書き出す。

**MOTD は利用者が入力した文字列がそのまま入る**ため、`shlex.quote` を通してから
書き出している。読み込み時に展開されると危険なため。

```console
入力: my server 'q' & $DANGER
出力: MC_NAME='my server '"'"'q'"'"' & $DANGER'
読込: MC_NAME=[my server 'q' & $DANGER]   ← 展開されずリテラルのまま
```

### 動作確認

- 引用符・`&`・`$VAR` を含むサーバー名で、`source` しても展開されないことを確認
- 生成されるテキストの全文をレンダリングして確認
- `shellcheck -x` / `bash -n` 指摘なし、全ファイル LF

**未確認:** 実機での生成とダウンロード。

---

## 追記: 待機中の進捗を 1 秒ごとの点で示す

出力を絞った結果、**長い処理の間は画面が完全に止まる**ようになった。
API の有効化は数分、インスタンスの作成も 1 分前後かかるため、
止まっているのか進んでいるのか分からない。

処理をバックグラウンドで走らせ、終わるまで 1 秒ごとに点を打つ形にした。

```
  Google Cloud の準備 ........................ 完了
  ネットワークの設定 ... 完了
  サーバーの作成 .................. 完了

マインクラフトの起動を待っています ............................
```

### `functions.sh`

- `wait_with_dots()` — 指定した PID が終わるまで点を打ち、**その終了ステータスを返す**
- `sleep_with_dots()` — 待つだけの箇所で使う
- `run_step()` をバックグラウンド実行に変更

### `create.sh`

API 有効化、再試行の待機、サービスアカウントの生成待ち、インスタンスの作成を点表示に変更した。

`instances create` は出力をファイルへ書き、`jq` で読むようにした。
バックグラウンドに回すとコマンド置換で受け取れないため。

### `wait_for_server` の間隔も揃えた

**実測で約 2 秒間隔だった。** ソケットのタイムアウト 1 秒と `sleep 1` が
積み上がっていたため。タイムアウトを 0.8 秒に下げ、次の刻みまでの残り時間だけ
眠るようにした。

```console
$ wait_for_server 192.0.2.1 12
  所要 : 12 秒
  点数 : 12 個
  間隔 : 1.0 秒/点     ← 修正前は約 2.0 秒/点
```

### 動作確認

| 検証 | 結果 |
| --- | --- |
| 4 秒かかる処理 | 点 4 個 → `完了` |
| 3 秒かかる処理が失敗 | 点 3 個 → `失敗` + 全文表示、戻り値 1 |
| `wait_for_server` の間隔 | 1.0 秒/点 |

- `shellcheck -x` / `bash -n` 指摘なし

---

## 追記: 進捗のラベルを「〜中」に統一

「サーバーの作成」だけでは、**これから行うのか実行中なのか**が読み取れない。
点が伸びている間は進行中であることが伝わる表記に変えた。

```
  Google Cloud の準備中 ........................ 完了
  ネットワークの設定中 ... 完了
  サーバーの作成中 .................. 完了

マインクラフト起動中 ............................
```

指示のあった 4 つに加えて、**他のスクリプトの同種の表記も揃えた。**
片方だけ「中」が付く状態になると、かえって不揃いに見えるため。

| 変更前 | 変更後 |
| --- | --- |
| Google Cloud の準備 | Google Cloud の準備中 |
| ネットワークの設定 | ネットワークの設定中 |
| サーバーの作成 | サーバーの作成中 |
| マインクラフトの起動を待っています | マインクラフト起動中 |
| サーバーの停止 / 再開 / 削除 | 〜中 |
| ネットワーク設定の削除 | ネットワーク設定の削除中 |
| ワールドの取得 / 書き戻し | 〜中 |
| データの検証 | データの検証中 |
| 確認しています / 準備しています | 確認中 / 準備中 |
| 更新しています | 更新中 |
| マインクラフトの再開 / 再起動を待っています | マインクラフト再開中 / 再起動中 |

`shellcheck -x` / `bash -n` 指摘なし、全ファイル LF。

---

## 追記: 既存サーバーがある場合は作成せず中止する

サーバーが既にある状態で `create` を選ぶと、**サーバー名からシード値まですべて
入力させたうえで**、最後に gcloud の生のエラーで落ちていた。

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The resource 'projects/.../instances/minecraft' already exists
```

無料枠で動かせるのは 1 台までなので、そもそも 2 台目は作れない。
**プロジェクトの確認を終えた直後、質問が始まる前に**検出して中止するようにした。

```
[ERROR] すでにマインクラフトサーバーが存在します。
        (A Minecraft server already exists in this project.)

 プロジェクト : minecraft-ydak-project-id
 状態         : 起動中
 IP アドレス  : 34.177.114.93

無料枠で動かせるサーバーは 1 台までのため、作成を中止しました。

 遊ぶ       : 上記の IP アドレスとポート 19132 で接続してください
 更新する   : メニューから update を選んでください
 作り直す   : メニューから delete を選んでから、もう一度 create してください

作り直すとワールドのデータも消えます。残したい場合は、先にメニューから
backup を実行してください。
```

**停止中のインスタンスも検出する。** 停止中は外部 IP を持たないため、
その旨を表示に含めた。

### 動作確認

gcloud をモックして 3 パターンを確認した。

| 状態 | 結果 |
| --- | --- |
| `RUNNING` + IP あり | 中止。状態「起動中」、IP を表示 |
| `TERMINATED` + IP なし | 中止。状態「停止中」、`(停止中のため割り当てなし)` |
| インスタンス無し | そのまま作成へ進む |

`shellcheck -x` / `bash -n` 指摘なし。

---

## 追記: SSH 鍵生成で無音のまま停止する不具合を修正

**実機で `backup` を試したところ、「確認中 ... 完了」の直後で止まった。**

```
WARNING: You do not have an SSH key for gcloud.
This tool needs to create the directory [/home/xxx/.ssh] before being able to generate SSH keys.
Do you want to continue (Y/n)?
```

`gcloud compute ssh` は初回に SSH 鍵の生成を対話で尋ねる。**この質問は stderr に出る**が、
呼び出し側で `2>/dev/null` に捨てていたため、画面には何も出ないまま入力待ちになっていた。

出力を絞る変更を入れたことで顕在化した不具合である。

### 対処

- **`gcloud compute ssh` すべてに `--quiet` を付けた。** 確認を自動で承諾し、
  パスフレーズ無しの鍵を生成する
- 鍵の生成と初回接続で 1 分近くかかるため、**進捗の点を出す**ようにした

### gcloud config の抑制漏れも修正

```
確認中 ... Your active configuration is: [cloudshell-24037]
Updated property [core/project].
完了
```

**これらも stderr に出る**ため、`> /dev/null` では消えていなかった。
`get project` と `set project` の双方を `2>&1` まで含めて抑制した。

### 進捗が出ないまま待つ箇所を無くした

| スクリプト | 箇所 |
| --- | --- |
| `backup` | ワールドサイズの取得、ワールドの取得 |
| `restore` | ワールドの書き戻し |
| `update` | OS 更新状態の確認 |

いずれもバックグラウンド実行に変え、`wait_with_dots` で終了を待つ。
`gcloud` の呼び出しで進捗が出ないまま待つ箇所は残っていない。

**未確認:** `--quiet` が鍵生成の確認を実際に自動承諾するか。
gcloud の仕様上そうなるはずだが、実機での確認が必要。

---

## 追記: リテラルの点を実時間の点に置き換える

`確認中 ... ` の点は**文字列に直接書かれたもので、常に 3 つ固定**だった。
1 秒ごとに増える箇所と混在しており、待ち時間の目安として読めない。

該当箇所をすべてバックグラウンド実行に変え、点が経過秒数を示すよう揃えた。

| 箇所 | スクリプト |
| --- | --- |
| 確認中 | create / update / delete / backup / restore |
| 準備中 | mc.sh |
| データの検証中 | backup / restore |
| 更新中 | update |

`gcloud` を呼んで進捗が出ないまま待つ箇所、およびリテラルの点は残っていない。

### 確認中の処理

プロジェクト ID と番号を取得するため、サブシェルの結果を一時ファイル経由で受け取る。
値は `printf %q` を通してから書き出し、読み込み時に展開されないようにしている。

`mc.sh` は `functions.sh` を読み込む**前**の処理なので、`wait_with_dots` を使わず
同等の待機ループを書いている。

### あわせて直した 2 点

- **`project_id` / `project_num` を事前に宣言した。** サブシェルの結果を `source` する
  形になり、shellcheck からは代入が見えないため
- **プロジェクトの取得に失敗した場合の検出を追加した。** バックグラウンドに回したことで
  `set -e` が効かなくなり、空のまま進んでいた

```
確認中 .. 失敗

[ERROR] Google Cloud のプロジェクトを取得できませんでした。
        下記で対象を指定してから、もう一度お試しください。

  gcloud config set project <プロジェクト ID>
```

`shellcheck -x` / `bash -n` 指摘なし、全ファイル LF。

---

## 追記: 進捗の点を 3 つから始める

点が 0 個から始まるため、処理に入った直後は**ラベルだけが表示され**、
一瞬だけ間の抜けた見た目になっていた。

3 つを初期表示とし、そこから 1 秒ごとに増やすようにした。

```
  即座に終わる処理 ....       (3 + 1)
  3 秒かかる処理 ......       (3 + 3)
  6 秒かかる処理 .........    (3 + 6)
  マインクラフト起動中 ........ (3 + 5)
```

`wait_with_dots` / `wait_for_server` / `mc.sh` の待機ループの 3 箇所すべてに
同じ初期表示を入れ、見え方を揃えた。

`sleep_with_dots` は初期表示を持たない。再試行の待機やサービスアカウントの
生成待ちなど、**既に点が出ている行の続き**として使うため。

`shellcheck -x` / `bash -n` 指摘なし。

---

## 追記: 描画距離を既定の 32 から 10 に下げる

`view-distance` の既定値は **32** で、無料枠の `e2-micro` には過大だった。

> **view-distance** — Default: `32`
> Allowed values: positive integers equal to `5` or greater. *Higher values have a performance impact.*

サーバーが送るデータの大半はチャンクである。32 チャンクぶん送る前提は、
**メモリ 1GB・共有コアという構成に対しても、下り 1GB/月 という無料枠に対しても
釣り合わない。**

`VIEW_DISTANCE=10` を `docker run` に追加した。

クライアント側の見た目は大きく変わらない。`client-side-chunk-generation-enabled` が
既定で有効なため、**遠景はクライアントが自前で生成する**。

### 圧縮は調整の余地が無いことも確認した

> **compression-threshold** — Default: `1`
> **compression-algorithm** — Default: `zlib`

**既に最も強い設定**であり、ここを触っても通信量は減らない。
`snappy` に変えれば CPU 負荷は下がるが、帯域は増える。

### サーバー情報ファイルにも記載

```
 最大人数     : 2
 シード値     : (ランダム)
 描画距離     : 10 チャンク (既定の 32 から下げています)
```

既定から変更している値なので、後から見て分かるようにしておく必要がある。

---

## 追記: サーバー情報のダウンロードを事前に予告する

起動待ちの後にダウンロードが始まるが、それを知らせるのがダウンロード開始時点だったため、
**待っている間に席を外すと見落とす。**

待機に入る前に予告を出すようにした。

```
  サーバーの作成中 ................. 完了

※ サーバー起動完了時、サーバー情報のファイルダウンロードが促されます。
   こちらをダウンロードし、保管してください。

マインクラフト起動中 ............................
```

この待ち時間は数分に及ぶため、戻ってきたときに何をすべきかが分かる位置に置く必要がある。
